### PR TITLE
Altert Channel.send on the inmemory layer to send a copy of the message.

### DIFF
--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -266,3 +266,15 @@ class ConformanceTestCase(unittest.TestCase):
         """
         self.assertTrue(hasattr(self.channel_layer, "MessageTooLarge"))
         self.assertTrue(hasattr(self.channel_layer, "ChannelFull"))
+
+    def test_message_alteration_after_send(self):
+        """
+        Tests that a message can be altert after it was send through a channel
+        without affecting the object inside the queue.
+        """
+        message = {'value': [1, 2, 3]}
+        self.channel_layer.send('channel', message)
+        message['value'][0] = 'new value'
+
+        _, message = self.channel_layer.receive_many(['channel'])
+        self.assertEqual(message, {'value': [1, 2, 3]})

--- a/asgiref/inmemory.py
+++ b/asgiref/inmemory.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from copy import deepcopy
 import random
 import six
 import string
@@ -50,7 +51,7 @@ class ChannelLayer(BaseChannelLayer):
                 raise self.ChannelFull(channel)
             queue.append((
                 time.time() + self.expiry,
-                message,
+                deepcopy(message),
             ))
 
     def receive_many(self, channels, block=False):


### PR DESCRIPTION
The following code acts different with the inmemory layer and the redis layer

```python
message = {'foo': [1,2,3]}
Channel('some_channel').send(message)
message['foo'][0] = 'new value'
```
The inmemory layer sends the object ```message ``` to the receiver and therefore the inner list as reverence. The redis layer creates a string from the message at the moment ```Channel(...).send()``` is called and therefore a copy of the message.

This pull request fixes this and both layers should work the same.