### PR TITLE
Add missed abstract method.

### DIFF
--- a/asgiref/base_layer.py
+++ b/asgiref/base_layer.py
@@ -53,6 +53,9 @@ class BaseChannelLayer(object):
     def group_discard(self, group, channel):
         raise NotImplementedError()
 
+    def group_channels(self, group):
+        raise NotImplementedError()
+
     def send_group(self, group, message):
         raise NotImplementedError()
 


### PR DESCRIPTION
This method used in all already implemented backends. Also it's required in the conformance test. I think it worth to add it in the base class.