### PR TITLE
Removing exceptions' redefinitions

### DIFF
--- a/asgiref/inmemory.py
+++ b/asgiref/inmemory.py
@@ -33,12 +33,6 @@ class ChannelLayer(BaseChannelLayer):
 
     extensions = ["groups", "flush"]
 
-    class ChannelFull(Exception):
-        pass
-
-    class MessageTooLarge(Exception):
-        pass
-
     def send(self, channel, message):
         # Make sure the message is a dict at least (no deep inspection)
         assert isinstance(message, dict), "Message is not a dict"


### PR DESCRIPTION
Removing redefinitions of `ChannelFull` and `MessageTooLarge`, as they are already defined in the`BaseChannelLayer`