### PR TITLE
tox, and all the Pythons 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 build/
 __pycache__/
 __pycache__/*
+/.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
+# Faster container-based infrastructure
 sudo: false
+
 language: python
+
+# Python versions supported by channel's supported Django versions
 python:
   - "2.7"
+  - "3.4"
   - "3.5"
+
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install unittest2; fi
-  - pip install six
-script: if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then python -m unittest2; else python -m unittest; fi
+  - pip install -e .
+  # Useful for debugging
+  - pip freeze
+
+script: python -m unittest discover

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,17 @@ WSGI-ASGI Adapters
 
 These are not yet complete and should not be used.
 
+Dependencies
+------------
+
+All Channels projects currently support Python 2.7, 3.4 and 3.5.
+
+Contributing
+------------
+
+Please refer to the
+`main Channels contributing docs <https://github.com/django/channels/blob/master/CONTRIBUTING.rst>`_.
+That also contains advice on how to set up the development environment and run the tests.
 
 Maintenance and Security
 ------------------------

--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -29,22 +29,10 @@ class ConformanceTestCase(unittest.TestCase):
     capacity_limit = None
 
     @classmethod
-    def raiseSkip(cls, message):
-        """
-        Picks the right skip class based on what version of unittest we're using.
-        """
-        try:
-            import unittest2
-            SkipTest = unittest2.SkipTest
-        except ImportError:
-            SkipTest = unittest.SkipTest
-        raise SkipTest(message)
-
-    @classmethod
     def setUpClass(cls):
         # Don't let this actual class run, it's abstract
         if cls is ConformanceTestCase:
-            cls.raiseSkip("Skipping base class tests")
+            raise unittest.SkipTest("Skipping base class tests")
 
     def setUp(self):
         if self.channel_layer is None:
@@ -60,7 +48,7 @@ class ConformanceTestCase(unittest.TestCase):
         We can't use the decorators, as we need access to self.
         """
         if extension not in self.channel_layer.extensions:
-            self.raiseSkip("No %s extension" % extension)
+            raise unittest.SkipTest("No %s extension" % extension)
 
     def test_send_recv(self):
         """
@@ -266,7 +254,7 @@ class ConformanceTestCase(unittest.TestCase):
         after the right number of messages. Only runs if capacity_limit is set.
         """
         if self.capacity_limit is None:
-            self.raiseSkip("No test capacity specified")
+            raise unittest.SkipTest("No test capacity specified")
         for _ in range(self.capacity_limit):
             self.channel_layer.send("cap_test", {"hey": "there"})
         with self.assertRaises(self.channel_layer.ChannelFull):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from setuptools import find_packages, setup
 from asgiref import __version__
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py34,py35
+
+[testenv]
+commands = python -m unittest discover


### PR DESCRIPTION
This pull requests introduced tox to be able to test against multiple Python versions locally, and configures tox and Travis so that they test against all Python versions supported by Channels. I also added a bit of documentation and cleanup.

I intend to make similar changes to the other Channels projects, so this pull request is a good occasion to discuss whether the same changes can and should be made to the other projects.