### PR TITLE
Optionally retry on receive in ConformanceTest

### DIFF
--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -74,14 +74,16 @@ class ConformanceTestCase(unittest.TestCase):
         self.channel_layer.send("sr_test", {"value": "green"})
         self.channel_layer.send("sr_test", {"value": "yellow"})
         self.channel_layer.send("sr_test2", {"value": "red"})
-        # Receive from the first channel twice; order is not guaranteed
+        # Receive from the first channel twice
         response_messages = []
         for i in range(3):
             channel, message = self.receive(["sr_test"])
+            response_messages.append(message)
             self.assertEqual(channel, "sr_test")
         for response in response_messages:
             self.assertTrue("value" in response)
-            self.assertTrue(response["value"] in set("blue", "green", "yellow"))
+        # Check that all messages were returned; order is not guaranteed
+        self.assertEqual(set([r["value"] for r in response_messages]), set("blue", "green", "yellow")))
         # And the other channel with multi select
         channel, message = self.receive(["sr_test", "sr_test2"])
         self.assertEqual(channel, "sr_test2")

--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -31,12 +31,11 @@ class ConformanceTestCase(unittest.TestCase):
 
     def receive(self, channels):
         """
-        Allows running tests that simulate a multi-worker environment in which an individual call to
-        receive() may not return a message. For example, a Redis-backed channel layer may have multiple
-        Redis connections but only read from one connection per receive() call. In such a case, the
-        developer should endeavor to make calls to receive() return a result deterministically (by
-        cycling through backend connections in order, for example) and set receive_tries to a value
-        that guarantees a result.
+        Allows tests to automatically call channel_layer.receive() more than once.
+        This is necessary for testing ChannelLayer implementations that do not guarantee a response will
+        be returned on every receive() call, even when there are messages on the channel. This would be
+        the case, for example, for a channel layer designed for a multi-worker environment with multiple
+        backing hosts, that checks a different host on each call.
         """
         for _ in range(self.receive_tries):
             channel, message = self.channel_layer.receive(channels)

--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -72,15 +72,16 @@ class ConformanceTestCase(unittest.TestCase):
         """
         self.channel_layer.send("sr_test", {"value": "blue"})
         self.channel_layer.send("sr_test", {"value": "green"})
+        self.channel_layer.send("sr_test", {"value": "yellow"})
         self.channel_layer.send("sr_test2", {"value": "red"})
-        # Get just one first
-        channel, message = self.receive(["sr_test"])
-        self.assertEqual(channel, "sr_test")
-        self.assertEqual(message, {"value": "blue"})
-        # And the second
-        channel, message = self.receive(["sr_test"])
-        self.assertEqual(channel, "sr_test")
-        self.assertEqual(message, {"value": "green"})
+        # Receive from the first channel twice; order is not guaranteed
+        response_messages = []
+        for i in range(3):
+            channel, message = self.receive(["sr_test"])
+            self.assertEqual(channel, "sr_test")
+        for response in response_messages:
+            self.assertTrue("value" in response)
+            self.assertTrue(response["value"] in set("blue", "green", "yellow"))
         # And the other channel with multi select
         channel, message = self.receive(["sr_test", "sr_test2"])
         self.assertEqual(channel, "sr_test2")

--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -38,7 +38,7 @@ class ConformanceTestCase(unittest.TestCase):
         cycling through backend connections in order, for example) and set receive_tries to a value
         that guarantees a result.
         """
-        for _ in range(self.receive_tries * len(channels)):
+        for _ in range(self.receive_tries):
             channel, message = self.channel_layer.receive(channels)
             if channel:
                 return channel, message

--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -83,7 +83,7 @@ class ConformanceTestCase(unittest.TestCase):
         for response in response_messages:
             self.assertTrue("value" in response)
         # Check that all messages were returned; order is not guaranteed
-        self.assertEqual(set([r["value"] for r in response_messages]), set("blue", "green", "yellow")))
+        self.assertEqual(set([r["value"] for r in response_messages]), set(["blue", "green", "yellow"])))
         # And the other channel with multi select
         channel, message = self.receive(["sr_test", "sr_test2"])
         self.assertEqual(channel, "sr_test2")

--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -83,7 +83,7 @@ class ConformanceTestCase(unittest.TestCase):
         for response in response_messages:
             self.assertTrue("value" in response)
         # Check that all messages were returned; order is not guaranteed
-        self.assertEqual(set([r["value"] for r in response_messages]), set(["blue", "green", "yellow"])))
+        self.assertEqual(set([r["value"] for r in response_messages]), set(["blue", "green", "yellow"]))
         # And the other channel with multi select
         channel, message = self.receive(["sr_test", "sr_test2"])
         self.assertEqual(channel, "sr_test2")

--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -38,7 +38,7 @@ class ConformanceTestCase(unittest.TestCase):
         cycling through backend connections in order, for example) and set receive_tries to a value
         that guarantees a result.
         """
-        for _ in range(self.receive_tries):
+        for _ in range(self.receive_tries * len(channels)):
             channel, message = self.channel_layer.receive(channels)
             if channel:
                 return channel, message

--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -39,7 +39,7 @@ class ConformanceTestCase(unittest.TestCase):
         """
         for _ in range(self.receive_tries):
             channel, message = self.channel_layer.receive(channels)
-            if channel:
+            if channel is not None:
                 return channel, message
         return None, None
 


### PR DESCRIPTION
Added an option to `ConformanceTestCase` that allows the test case to retry receiving. This is necessary for testing `ChannelLayer` implementations that do not guarantee a response will be returned on every `receive()` call, even when there are messages on the channel. This would be the case, for example, for a channel layer designed for a multi-worker environment with multiple backing hosts, that checks a different host on each call.

Also fixed `test_send_recv` so that it does not depend on the order in which messages are returned, since order is not guaranteed in the spec.