### PR TITLE
Verify async extension against its methods.

### DIFF
--- a/asgiref/conformance.py
+++ b/asgiref/conformance.py
@@ -349,3 +349,24 @@ class ConformanceTestCase(unittest.TestCase):
     # in a separate file.
     if six.PY3:
         from .conformance_async import test_receive_async
+
+    def test_async_extension(self):
+        """
+        If channel layer says it support async extension, it must have
+        proper methods.  Otherwise, it should not.
+        """
+
+        if 'async' in self.channel_layer.extensions:
+            self.assertTrue(
+                hasattr(self.channel_layer, 'receive_async'),
+                '%s should have receive_async method' % (
+                    self.channel_layer.__class__.__name__,
+                ),
+            )
+        else:
+            self.assertFalse(
+                hasattr(self.channel_layer, 'receive_async'),
+                '%s should not have receive_async method' % (
+                    self.channel_layer.__class__.__name__,
+                ),
+            )

--- a/asgiref/inmemory.py
+++ b/asgiref/inmemory.py
@@ -31,7 +31,7 @@ class ChannelLayer(BaseChannelLayer):
 
     ### ASGI API ###
 
-    extensions = ["groups", "flush", "async"]
+    extensions = ["groups", "flush"]
 
     def send(self, channel, message):
         # Make sure the message is a dict at least (no deep inspection)
@@ -145,6 +145,7 @@ class ChannelLayer(BaseChannelLayer):
     # in a separate file.
     if six.PY3:
         from .inmemory_async import receive_async
+        extensions.append("async")
 
     ### Expire cleanup ###
 


### PR DESCRIPTION
Just to be more precise.

Should we do the same for `twisted` extension?