### PR TITLE
Add classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,19 @@ setup(
     entry_points={'console_scripts': [
         'asgiref_benchmark = asgiref.benchmark:Benchmarker.cli',
     ]},
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Web Environment',
+        'Framework :: Django',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Internet :: WWW/HTTP',
+    ],
 )


### PR DESCRIPTION
Without language classifiers in `setup.py` this project gets marked as not supporting Python 3 when using a tool like [caniusepython3.com](https://caniusepython3.com) to check Python 3 compatibility. I copied the classifiers from `channels` as they seemed applicable.