### PR TITLE
Improve channel and group name validation

### DIFF
--- a/asgiref/base_layer.py
+++ b/asgiref/base_layer.py
@@ -93,10 +93,12 @@ class BaseChannelLayer(object):
                 return capacity
         return self.capacity
 
-    def match_type_and_length(self, name):
-        if (len(name) < 100) and (isinstance(name, six.text_type)):
-            return True
-        return False
+    def validate_name_type_and_length(self, name):
+        if len(name) >= 100:
+            raise TypeError("Channel and group names must be under 100 characters in length.")
+        if not isinstance(name, six.text_type):
+            raise TypeError("Channel or group name is not of 'str' type: {}.".format(type(name)))
+        return True
 
     ### Name validation functions
 
@@ -106,20 +108,20 @@ class BaseChannelLayer(object):
                          "underscores, or periods, not '{}'."
 
     def valid_channel_name(self, name, receive=False):
-        if self.match_type_and_length(name):
-            if bool(self.channel_name_regex.match(name)):
-                # Check cases for special channels
-                if "?" in name and name.endswith("?"):
-                    raise TypeError("Single-reader channel names must not end with ?")
-                elif "!" in name and not name.endswith("!") and receive:
-                    raise TypeError("Process-local channel names in receive() must end at the !")
-                return True
+        self.validate_name_type_and_length(name)
+        if bool(self.channel_name_regex.match(name)):
+            # Check cases for special channels
+            if "?" in name and name.endswith("?"):
+                raise TypeError("Single-reader channel names must not end with ?")
+            elif "!" in name and not name.endswith("!") and receive:
+                raise TypeError("Process-local channel names in receive() must end at the !")
+            return True
         raise TypeError(self.invalid_name_error.format("Channel", name))
 
     def valid_group_name(self, name):
-        if self.match_type_and_length(name):
-            if bool(self.group_name_regex.match(name)):
-                return True
+        self.validate_name_type_and_length(name)
+        if bool(self.group_name_regex.match(name)):
+            return True
         raise TypeError(self.invalid_name_error.format("Group", name))
 
     def valid_channel_names(self, names, receive=False):

--- a/asgiref/base_layer.py
+++ b/asgiref/base_layer.py
@@ -102,7 +102,8 @@ class BaseChannelLayer(object):
 
     channel_name_regex = re.compile(r"^[a-zA-Z\d\-_.]+((\?|\!)[\d\w\-_.]*)?$")
     group_name_regex = re.compile(r"^[a-zA-Z\d\-_.]+$")
-    invalid_name_error = "{} name must be a valid unicode string containing only ASCII alphanumerics, hyphens, underscores, or periods."
+    invalid_name_error = "{} name must be a valid unicode string containing only ASCII alphanumerics, hyphens, " \
+                         "underscores, or periods, not '{}'."
 
     def valid_channel_name(self, name, receive=False):
         if self.match_type_and_length(name):
@@ -113,13 +114,13 @@ class BaseChannelLayer(object):
                 elif "!" in name and not name.endswith("!") and receive:
                     raise TypeError("Process-local channel names in receive() must end at the !")
                 return True
-        raise TypeError("Channel name must be a valid unicode string containing only ASCII alphanumerics, hyphens, or periods, not '{}'.".format(name))
+        raise TypeError(self.invalid_name_error.format("Channel", name))
 
     def valid_group_name(self, name):
         if self.match_type_and_length(name):
             if bool(self.group_name_regex.match(name)):
                 return True
-        raise TypeError("Group name must be a valid unicode string containing only ASCII alphanumerics, hyphens, or periods.")
+        raise TypeError(self.invalid_name_error.format("Group", name))
 
     def valid_channel_names(self, names, receive=False):
         _non_empty_list = True if names else False


### PR DESCRIPTION
Got hit by a situation where my group name was over 100 characters but the system was saying it contained illegal characters, which was a bit confusing. Trying to improve the messages coming out of the validation with these commits.

* Functions valid_channel_name and valid_group_name were using almost the same error message. Unified both to use the class 'invalid_name_error' attribute. This also added to the error message the underscore as a valid character. It was a valid character all the time but was missing from the raised error.

* Refactor BaseChannelLayer.match_type_and_length. Channel and group names are also restricted in length and type, but if those fail to validate we got a validation message related to characters in the name. Raise a separate TypeError to indicate clearly whether it was the length or the type that failed validation.

Thanks for making Channels!