### PR TITLE
ApplicationCommunicator's receive_nothing

### DIFF
--- a/asgiref/testing.py
+++ b/asgiref/testing.py
@@ -88,16 +88,12 @@ class ApplicationCommunicator:
         """
         Checks that there is no message to receive in the given time.
         """
-        # No reason to wait if there is a message already
-        if not self.output_queue.empty():
-            return False
-        # Keep time to wait short if possible
-        if timeout <= attempt:
+        if attempt > 0:
+            for i in range(int(timeout // attempt)):
+                if not self.output_queue.empty():
+                    return False
+                await asyncio.sleep(attempt)
+            await asyncio.sleep(timeout % attempt)
+        else:
             await asyncio.sleep(timeout)
-            return self.output_queue.empty()
-        await asyncio.sleep(attempt)
-        if not self.output_queue.empty():
-            return False
-        # Wait for the timeout
-        await asyncio.sleep(timeout - attempt)
         return self.output_queue.empty()

--- a/asgiref/testing.py
+++ b/asgiref/testing.py
@@ -83,3 +83,21 @@ class ApplicationCommunicator:
                 except CancelledError:
                     pass
             raise e
+
+    async def receive_nothing(self, timeout=0.1, attempt=0.01):
+        """
+        Checks that there is no message to receive in the given time.
+        """
+        # No reason to wait if there is a message already
+        if not self.output_queue.empty():
+            return False
+        # Keep time to wait short if possible
+        if timeout <= attempt:
+            await asyncio.sleep(timeout)
+            return self.output_queue.empty()
+        await asyncio.sleep(attempt)
+        if not self.output_queue.empty():
+            return False
+        # Wait for the timeout
+        await asyncio.sleep(timeout - attempt)
+        return self.output_queue.empty()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,67 @@
+import math
+import time
+
+import pytest
+
+from asgiref.testing import ApplicationCommunicator
+from asgiref.wsgi import WsgiToAsgi
+
+
+@pytest.mark.parametrize(
+    "event, timeout, attempt, duration, tolerance, expected", [
+        # No event
+        # Standard values
+        (False, 0.1, 0.01, 0.1, 0.03, True),
+        # attempt > timeout
+        (False, 0.1, 1, 0.1, 0.03, True),
+        # timeout % attempt > 0
+        (False, 1, 0.6, 1, 0.03, True),
+
+        # Events
+        # Standard values
+        (True, 0.1, 0.01, 0.01, 0.003, False),
+        # No delay
+        (True, 0, 0.01, 0, 0.003, True),
+        # No attempt
+        (True, 0.1, 0, 0.1, 0.03, False),
+        # attempt > timeout
+        (True, 0.1, 1, 0.1, 0.03, False),
+    ]
+)
+@pytest.mark.asyncio
+async def test_receive_nothing(event, timeout, attempt, duration, tolerance, expected):
+    """
+    Tests ApplicationCommunicator.receive_nothing with different parameters.
+    """
+    # Get an ApplicationCommunicator instance
+    def wsgi_application(environ, start_response):
+        start_response("200 OK", [])
+        yield b"content"
+    application = WsgiToAsgi(wsgi_application)
+    instance = ApplicationCommunicator(application, {
+        "type": "http",
+        "http_version": "1.0",
+        "method": "GET",
+        "path": "/foo/",
+        "query_string": b"bar=baz",
+        "headers": [],
+    })
+
+    if event:
+        await instance.send_input({
+            "type": "http.request",
+        })
+
+    start = time.monotonic()
+    result = await instance.receive_nothing(timeout=timeout, attempt=attempt)
+    end = time.monotonic()
+    assert result is expected
+    assert math.isclose(end - start, duration, abs_tol=tolerance)
+
+    if event:
+        await instance.receive_output()
+        assert await instance.receive_nothing() is False
+        await instance.receive_output()
+        assert await instance.receive_nothing() is False
+        await instance.receive_output()
+        assert await instance.receive_nothing(0.01) is True

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -26,14 +26,18 @@ async def test_receive_nothing():
     # No event
     assert await instance.receive_nothing() is True
 
-    # Events
+    # Produce 3 events to receive
     await instance.send_input({
         "type": "http.request",
     })
+    # Start event of the response
     assert await instance.receive_nothing() is False
     await instance.receive_output()
+    # First body event of the response announcing further body event
     assert await instance.receive_nothing() is False
     await instance.receive_output()
+    # Last body event of the response
     assert await instance.receive_nothing() is False
     await instance.receive_output()
+    # Response received completely
     assert await instance.receive_nothing(0.01) is True

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -8,28 +8,28 @@ from asgiref.wsgi import WsgiToAsgi
 
 
 @pytest.mark.parametrize(
-    "event, timeout, attempt, duration, tolerance, expected", [
+    "event, timeout, interval, duration, tolerance, expected", [
         # No event
         # Standard values
         (False, 0.1, 0.01, 0.1, 0.03, True),
-        # attempt > timeout
-        (False, 0.1, 1, 0.1, 0.03, True),
-        # timeout % attempt > 0
-        (False, 1, 0.6, 1, 0.03, True),
+        # interval > timeout (interval has precedence over timeout)
+        (False, 0.1, 1, 1, 0.03, True),
+        # timeout % interval > 0 (interval cycle completes)
+        (False, 1, 0.6, 1.2, 0.03, True),
 
         # Events
         # Standard values
         (True, 0.1, 0.01, 0.01, 0.003, False),
         # No delay
         (True, 0, 0.01, 0, 0.003, True),
-        # No attempt
-        (True, 0.1, 0, 0.1, 0.03, False),
-        # attempt > timeout
-        (True, 0.1, 1, 0.1, 0.03, False),
+        # No interval
+        (True, 0.1, 0, 0, 0.003, False),
+        # interval > timeout (interval has precedence over timeout)
+        (True, 0.1, 1, 1, 0.03, False),
     ]
 )
 @pytest.mark.asyncio
-async def test_receive_nothing(event, timeout, attempt, duration, tolerance, expected):
+async def test_receive_nothing(event, timeout, interval, duration, tolerance, expected):
     """
     Tests ApplicationCommunicator.receive_nothing with different parameters.
     """
@@ -53,7 +53,7 @@ async def test_receive_nothing(event, timeout, attempt, duration, tolerance, exp
         })
 
     start = time.monotonic()
-    result = await instance.receive_nothing(timeout=timeout, attempt=attempt)
+    result = await instance.receive_nothing(timeout=timeout, interval=interval)
     end = time.monotonic()
     assert result is expected
     assert math.isclose(end - start, duration, abs_tol=tolerance)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,37 +1,13 @@
-import math
-import time
-
 import pytest
 
 from asgiref.testing import ApplicationCommunicator
 from asgiref.wsgi import WsgiToAsgi
 
 
-@pytest.mark.parametrize(
-    "event, timeout, interval, duration, tolerance, expected", [
-        # No event
-        # Standard values
-        (False, 0.1, 0.01, 0.1, 0.03, True),
-        # interval > timeout (interval has precedence over timeout)
-        (False, 0.1, 1, 1, 0.03, True),
-        # timeout % interval > 0 (interval cycle completes)
-        (False, 1, 0.6, 1.2, 0.03, True),
-
-        # Events
-        # Standard values
-        (True, 0.1, 0.01, 0.01, 0.003, False),
-        # No delay
-        (True, 0, 0.01, 0, 0.003, True),
-        # No interval
-        (True, 0.1, 0, 0, 0.003, False),
-        # interval > timeout (interval has precedence over timeout)
-        (True, 0.1, 1, 1, 0.03, False),
-    ]
-)
 @pytest.mark.asyncio
-async def test_receive_nothing(event, timeout, interval, duration, tolerance, expected):
+async def test_receive_nothing():
     """
-    Tests ApplicationCommunicator.receive_nothing with different parameters.
+    Tests ApplicationCommunicator.receive_nothing to return the correct value.
     """
     # Get an ApplicationCommunicator instance
     def wsgi_application(environ, start_response):
@@ -47,21 +23,17 @@ async def test_receive_nothing(event, timeout, interval, duration, tolerance, ex
         "headers": [],
     })
 
-    if event:
-        await instance.send_input({
-            "type": "http.request",
-        })
+    # No event
+    assert await instance.receive_nothing() is True
 
-    start = time.monotonic()
-    result = await instance.receive_nothing(timeout=timeout, interval=interval)
-    end = time.monotonic()
-    assert result is expected
-    assert math.isclose(end - start, duration, abs_tol=tolerance)
-
-    if event:
-        await instance.receive_output()
-        assert await instance.receive_nothing() is False
-        await instance.receive_output()
-        assert await instance.receive_nothing() is False
-        await instance.receive_output()
-        assert await instance.receive_nothing(0.01) is True
+    # Events
+    await instance.send_input({
+        "type": "http.request",
+    })
+    assert await instance.receive_nothing() is False
+    await instance.receive_output()
+    assert await instance.receive_nothing() is False
+    await instance.receive_output()
+    assert await instance.receive_nothing() is False
+    await instance.receive_output()
+    assert await instance.receive_nothing(0.01) is True


### PR DESCRIPTION
Addresses #32.

On my computer it took < 0.001 s to send a message via (Channels') `group_send` using the `InMemoryChannelLayer`. Therefore an attempt after 0.01 s should actually be enough. Please let me know if you prefered a simpler implementation.

**ToDo**

- [x] tests (or not necessary? – There are no tests for testing.)
- [x] docs (in Channels repo)