### PR TITLE
Cross-reference "HTTP & WebSocket" in ASGI spec

### DIFF
--- a/specs/asgi.rst
+++ b/specs/asgi.rst
@@ -211,7 +211,7 @@ defined by the protocol spec. Examples of a message ``type`` value include
 
 Current protocol specifications:
 
-* `HTTP and WebSocket <https://github.com/django/asgiref/blob/master/specs/www.rst>`_
+* :doc:`HTTP and WebSocket <www>`
 
 
 Middleware


### PR DESCRIPTION
Instead of linking to the raw rst version on github, use a cross-reference
to "www" document so that navigation stays within generated
documentation and the reader gets a rendered version.