### PR TITLE
Allow for http.disconnect after response sending

### DIFF
--- a/specs/www.rst
+++ b/specs/www.rst
@@ -152,9 +152,10 @@ Keys:
 Disconnect
 ''''''''''
 
-Sent to the application when a HTTP connection is closed. This is mainly
-useful for long-polling, where you may want to trigger cleanup code if
-the connection closes early.
+Sent to the application when a HTTP connection is closed or if receive
+is called after a response has been sent. This is mainly useful for
+long-polling, where you may want to trigger cleanup code if the
+connection closes early.
 
 Keys:
 


### PR DESCRIPTION
This allows for ASGI applications to call the receive after sending a
response by indicating the application should receive a disconnect
message. This in turn allows the sending and receiving tasks to have
separate lifespans.

The use case I have in mind (and use in Quart) is something like,
```
async def application_instance(receive, send):
    while True:
        message = await receive()
        task = asyncio.ensure_future(sending_task(send))  # Separate lifespan
        if message['type'] == 'http.disconnect':
            task.cancel()
            break
        ...
```

At the moment Uvicorn (as the motivating example) interprets this a different want and raises an error in the receive after the sending is complete.