### PR TITLE
Drop API Star from implementations.

### DIFF
--- a/docs/implementations.rst
+++ b/docs/implementations.rst
@@ -48,14 +48,6 @@ original driving force behind the ASGI project. Supports HTTP and WebSockets
 with Django integration, and any protocol with ASGI-native code.
 
 
-API Star
---------
-
-*Beta* / https://github.com/encode/apistar
-
-A smart Web API framework that runs via ASGI. Supports HTTP.
-
-
 Quart
 -----
 


### PR DESCRIPTION
Drop API Star, since from 0.6 onwards it's [descoped into a framework-agnostic suite of API tools](https://github.com/encode/apistar/pull/624), rather than a complete server implementation. (Starlette has picked up the mantle for my own work on an ASGI framework implementation.)