### PR TITLE
Clarify www spec for path definition

### DIFF
--- a/specs/www.rst
+++ b/specs/www.rst
@@ -60,8 +60,9 @@ The connection scope contains:
 * ``scheme``: Unicode string URL scheme portion (likely ``http`` or ``https``).
   Optional (but must not be empty), default is ``"http"``.
 
-* ``path``: Unicode string HTTP path from URL, with percent escapes decoded
-  and UTF-8 byte sequences decoded into characters.
+* ``path``: Unicode string HTTP request target excluding any query
+  string, with percent escapes decoded and UTF-8 byte sequences
+  decoded into characters.
 
 * ``query_string``: Byte string URL portion after the ``?``, not url-decoded.
 
@@ -191,7 +192,9 @@ contains the initial connection metadata (mostly from the HTTP handshake):
 * ``scheme``: Unicode string URL scheme portion (likely ``ws`` or ``wss``).
   Optional (but must not be empty), default is ``ws``.
 
-* ``path``: Unicode HTTP path from URL, already urldecoded.
+* ``path``: Unicode string HTTP request target excluding any query
+  string, with percent escapes decoded and UTF-8 byte sequences
+  decoded into characters.
 
 * ``query_string``: Byte string URL portion after the ``?``. Optional, default
   is empty string.


### PR DESCRIPTION
RFC 7320 section 5.3 allows for the request target to be in an
absolute form (5.3.1) which servers MUST allow. The current ASGI
servers (Hypercorn, Uvicorn & Daphne) will all pass on the full
request-target (minus query string) to the ASGI application rather
than, as the previous version of this specification suggested, just
the path part of the URL. This should help ASGI app developers
understand whether to assume the path will always be just the path.