### PR TITLE
Add http_version to the Websocket scope

### DIFF
--- a/specs/www.rst
+++ b/specs/www.rst
@@ -189,6 +189,9 @@ contains the initial connection metadata (mostly from the HTTP handshake):
 
 * ``type``: ``websocket``
 
+* ``http_version``: Unicode string, one of ``1.1`` or ``2``. Optional,
+  default is ``1.1``.
+
 * ``scheme``: Unicode string URL scheme portion (likely ``ws`` or ``wss``).
   Optional (but must not be empty), default is ``ws``.
 


### PR DESCRIPTION
This is required now that websockets over HTTP/2 has been defined in
RFC 8441.