### PR TITLE
Clarify general and spec documentation

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -9,7 +9,7 @@ some common extensions.
 Websocket Denial Response
 -------------------------
 
-Websocket connections start with the client sending an HTTP request
+Websocket connections start with the client sending a HTTP request
 containing the appropriate upgrade headers. On receipt of this request
 a server can choose to either upgrade the connection or respond with an
 HTTP response (denying the upgrade). The core ASGI specification does

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -9,16 +9,16 @@ some common extensions.
 Websocket Denial Response
 -------------------------
 
-Websocket connections start with the user agent sending a HTTP request
+Websocket connections start with the client sending an HTTP request
 containing the appropriate upgrade headers. On receipt of this request
-a server can choose to either upgrade the connection or respond with a
+a server can choose to either upgrade the connection or respond with an
 HTTP response (denying the upgrade). The core ASGI specification does
-not allow for any control over the denial-response, instead specifying
+not allow for any control over the denial response, instead specifying
 that the HTTP status code ``403`` should be returned, whereas this
 extension allows an ASGI framework to control the
-denial-response. This is an extension, rather than a core part of
-ASGI, as most user agents do not utilise the denial response and hence
-this is a niche feature.
+denial response. Rather than being a core part of
+ASGI, this is an extension for what is considered a niche feature as most
+clients do not utilise the denial response.
 
 ASGI Servers that implement this extension will provide
 ``websocket.http.response`` in the extensions part of the scope::
@@ -55,19 +55,19 @@ push promise. ASGI servers that implement this extension will provide
     }
 
 An ASGI framework can initiate a server push by sending a message with
-the following keys, This message can be sent at any time after the
+the following keys. This message can be sent at any time after the
 *Response Start* message but before the final *Response Body* message.
 
 Keys:
 
-* ``type``: ``http.response.push``
+* ``type`` (*Unicode string*): ``"http.response.push"``
 
-* ``path``: Unicode string HTTP path from URL, with percent escapes
-  decoded and UTF-8 byte sequences decoded into characters.
+* ``path`` (*Unicode string*): HTTP path from URL, with percent-encoded
+  sequences and UTF-8 byte sequences decoded into characters.
 
-* ``headers``: A list of ``[name, value]`` lists, where ``name`` is the
-  byte string header name, and ``value`` is the byte string
-  header value. Header names must be lowercased.
+* ``headers`` (*Iterable[[byte string, byte string]]*): An iterable of
+  ``[name, value]`` two-item iterables, where ``name`` is the header name, and
+  ``value`` is the header value. Header names must be lowercased.
 
 The ASGI server should then attempt to send a server push (or push
 promise) to the client. If the client accepts, the server should create

--- a/docs/implementations.rst
+++ b/docs/implementations.rst
@@ -2,7 +2,7 @@
 Implementations
 ===============
 
-Complete or upcoming implementations of ASGI---servers, frameworks, and other
+Complete or upcoming implementations of ASGI - servers, frameworks, and other
 useful pieces.
 
 Servers

--- a/docs/implementations.rst
+++ b/docs/implementations.rst
@@ -2,7 +2,7 @@
 Implementations
 ===============
 
-Complete or upcoming implementations of ASGI - servers, frameworks, and other
+Complete or upcoming implementations of ASGI---servers, frameworks, and other
 useful pieces.
 
 Servers

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -29,7 +29,7 @@ receiving WebSocket frames) can't trigger this.
 How does ASGI work?
 -------------------
 
-ASGI is structured as a double-callable---the first callable takes a
+ASGI is structured as a double-callable - the first callable takes a
 ``scope``, which contains details about the incoming request, and returns a
 second, coroutine callable. This second callable is given ``send`` and
 ``receive`` awaitables that allow the coroutine to monitor incoming events and

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -29,11 +29,11 @@ receiving WebSocket frames) can't trigger this.
 How does ASGI work?
 -------------------
 
-ASGI is structured as a double-callable - the first callable takes a ``scope``,
-which contains details about the incoming request, and returns a second,
-coroutine callable. This second callable gets given ``send`` and ``receive``
-awaitables that allow the coroutine to monitor incoming events and send
-outgoing events.
+ASGI is structured as a double-callable---the first callable takes a
+``scope``, which contains details about the incoming request, and returns a
+second, coroutine callable. This second callable is given ``send`` and
+``receive`` awaitables that allow the coroutine to monitor incoming events and
+send outgoing events.
 
 This not only allows multiple incoming events and outgoing events for each
 application, but also allows for a background coroutine so the application can
@@ -56,9 +56,9 @@ Every *event* that you send or receive is a Python ``dict``, with a predefined
 format. It's these event formats that form the basis of the standard, and allow
 applications to be swappable between servers.
 
-These *events* each have a defined ``type`` key, so you know what it is to look
-for. Here's an example event for sending the start of a HTTP response that
-you might get from ``receive``::
+These *events* each have a defined ``type`` key, which can be used to infer
+the event's structure. Here's an example event for sending the start of a HTTP
+response that you might get from ``receive``::
 
     {
         "type": "http.response.start",

--- a/docs/specs/index.rst
+++ b/docs/specs/index.rst
@@ -1,10 +1,9 @@
 Specifications
 ==============
 
-These are the specifications for ASGI. There's a root specification, which
-specifies how applications are structured and called, and then protocol
-specifications, that outline the events that can be sent and received for
-each protocol.
+These are the specifications for ASGI. The root specification outlines how
+applications are structured and called, and the protocol specifications outline
+the events that can be sent and received for each protocol.
 
 
 .. toctree::

--- a/specs/asgi.rst
+++ b/specs/asgi.rst
@@ -235,8 +235,9 @@ defined by the protocol spec. Examples of a message ``type`` value include
 
   Applications should actively reject any protocol that they do not understand
   with an `Exception` (of any type). Failure to do this may result in the
-  server thinking you support a protocol you don't, which can complicate the
-  Lifespan protocol, as the server will wait to start until you tell it.
+  server thinking you support a protocol you don't, which can be confusing when
+  using with the Lifespan protocol, as the server will wait to start until you
+  tell it.
 
 
 Current protocol specifications:

--- a/specs/asgi.rst
+++ b/specs/asgi.rst
@@ -114,14 +114,14 @@ Events
 ------
 
 ASGI decomposes protocols into a series of *events* that an application must
-react to. For HTTP, this is as simple as two events in order---``http.request``
+react to. For HTTP, this is as simple as two events in order - ``http.request``
 and ``http.disconnect``. For something like a WebSocket, it could be more like
 ``websocket.connect``, ``websocket.send``, ``websocket.receive``, and finally
 ``websocket.disconnect``.
 
 Each event is a ``dict`` with a top-level ``type`` key that contains a
 Unicode string of the message type. Users are free to invent their own message
-types and send them between application instances for high-level events---for
+types and send them between application instances for high-level events - for
 example, a chat application might send chat messages with a user type of
 ``mychat.message``. It is expected that applications should be able to handle
 a mixed set of events, some sourced from the incoming client connection and
@@ -246,7 +246,7 @@ Current protocol specifications:
 Middleware
 ----------
 
-It is possible to have ASGI "middleware"---code that plays the role of both
+It is possible to have ASGI "middleware" - code that plays the role of both
 server and application, taking in a scope and the send/receive awaitables,
 potentially modifying them, and then calling an inner application.
 
@@ -263,9 +263,9 @@ control to the child application.
 Error Handling
 --------------
 
-If a server receives an invalid event dictionary---for example, having an
+If a server receives an invalid event dictionary - for example, having an
 unknown ``type``, missing keys an event type should have, or with wrong Python
-types for objects (e.g. Unicode strings for HTTP headers), it should raise an
+types for objects (e.g. Unicode strings for HTTP headers) - it should raise an
 exception out of the ``send`` awaitable back to the application.
 
 If an application receives an invalid event dictionary from ``receive``, it
@@ -276,8 +276,8 @@ not raise an exception. This allows non-breaking upgrades to protocol
 specifications over time.
 
 Servers are free to surface errors that bubble up out of application instances
-they are running however they wish---log to console, send to syslog, or other
-options---but they must terminate the application instance and its associated
+they are running however they wish - log to console, send to syslog, or other
+options - but they must terminate the application instance and its associated
 connection if this happens.
 
 Note that messages received by a server after the connection has been
@@ -306,7 +306,7 @@ There are times when protocol servers may want to provide server-specific
 extensions outside of a core ASGI protocol specification, or when a change
 to a specification is being trialled before being rolled in.
 
-For this use case, we define a common pattern for ``extensions``---named
+For this use case, we define a common pattern for ``extensions`` - named
 additions to a protocol specification that are optional but that, if provided
 by the server and understood by the application, can be used to get more
 functionality.
@@ -347,7 +347,7 @@ In this document, and all sub-specifications, *byte string* refers to
 the ``bytes`` type in Python 3. *Unicode string* refers to the ``str`` type
 in Python 3.
 
-This document will never specify just *string*---all strings are one of the
+This document will never specify just *string* - all strings are one of the
 two exact types.
 
 All ``dict`` keys mentioned (including those for *scopes* and *events*) are

--- a/specs/asgi.rst
+++ b/specs/asgi.rst
@@ -24,24 +24,24 @@ Rationale
 The WSGI specification has worked well since it was introduced, and
 allowed for great flexibility in Python framework and web server choice.
 However, its design is irrevocably tied to the HTTP-style
-request/response cycle, and more and more protocols are becoming a
-standard part of web programming that do not follow this pattern
-(most notably, WebSocket).
+request/response cycle, and more and more protocols that do not follow this
+pattern are becoming a standard part of web programming (most notably,
+WebSocket).
 
-ASGI attempts to preserve a simple application interface, but provide
-an abstraction that allows for data to be sent and received at any time,
-and from different application threads or processes.
+ASGI attempts to preserve a simple application interface, while providing an
+abstraction that allows for data to be sent and received at any time, and from
+different application threads or processes.
 
-It also take the principle of turning protocols into Python-compatible,
+It also takes the principle of turning protocols into Python-compatible,
 asynchronous-friendly sets of messages and generalises it into two parts;
-a standardised interface for communication and to build servers around (this
+a standardised interface for communication around which to build servers (this
 document), and a set of standard message formats for each protocol.
 
-Its primary goal is to provide a way to write HTTP/2 and WebSocket code,
-alongside normal HTTP handling code, however, and part of this design is
+Its primary goal is to provide a way to write HTTP/2 and WebSocket code
+alongside normal HTTP handling code, however; part of this design means
 ensuring there is an easy path to use both existing WSGI servers and
 applications, as a large majority of Python web usage relies on WSGI and
-providing an easy path forwards is critical to adoption. Details on that
+providing an easy path forward is critical to adoption. Details on that
 interoperability are covered in the ASGI-HTTP spec.
 
 
@@ -89,7 +89,7 @@ Connection Scope
 
 Every connection by a user to an ASGI application results in an instance of
 that application being created for the connection. How long this lives, and
-what information it gets given upon creation, is called the *connection scope*.
+what information it receives upon creation, is called the *connection scope*.
 
 For example, under HTTP the connection scope lasts just one request, but it
 contains most of the request data (apart from the HTTP request body, as this
@@ -97,7 +97,7 @@ is streamed in via events).
 
 Under WebSocket, though, the connection scope lasts for as long as the socket
 is connected. The scope contains information like the WebSocket's path, but
-details like incoming messages come through as Events instead.
+details like incoming messages come through as events instead.
 
 Some protocols may give you a connection scope with very limited information up
 front because they encapsulate something like a handshake. Each protocol
@@ -106,7 +106,7 @@ and what information you will get inside it.
 
 Applications **cannot** communicate with the client when they are
 initialized and given their connection scope; they must wait until their
-event loop is entered, and depending on the protocol spec, may have to
+event loop is entered and, depending on the protocol spec, may have to
 wait for an initial opening message.
 
 
@@ -114,16 +114,16 @@ Events
 ------
 
 ASGI decomposes protocols into a series of *events* that an application must
-react to. For HTTP, this is as simple as two events in order - ``http.request``
+react to. For HTTP, this is as simple as two events in order---``http.request``
 and ``http.disconnect``. For something like a WebSocket, it could be more like
-``websocket.connect``, ``websocket.send``, ``websocket.receive``,
+``websocket.connect``, ``websocket.send``, ``websocket.receive``, and finally
 ``websocket.disconnect``.
 
 Each event is a ``dict`` with a top-level ``type`` key that contains a
-unicode string of the message type. Users are free to invent their own message
-types and send them between application instances for high-level events - for
+Unicode string of the message type. Users are free to invent their own message
+types and send them between application instances for high-level events---for
 example, a chat application might send chat messages with a user type of
-``mychat.message``. It is expected that applications would be able to handle
+``mychat.message``. It is expected that applications should be able to handle
 a mixed set of events, some sourced from the incoming client connection and
 some from other parts of the application.
 
@@ -132,10 +132,11 @@ serializable, and so they are only allowed to contain the following types:
 
 * Byte strings
 * Unicode strings
-* Integers (within the signed 64 bit range)
-* Floating point numbers (within the IEEE 754 double precision range, no ``Nan`` or infinities)
+* Integers (within the signed 64-bit range)
+* Floating point numbers (within the IEEE 754 double precision range; no
+  ``Nan`` or infinities)
 * Lists (tuples should be encoded as lists)
-* Dicts (keys must be unicode strings)
+* Dicts (keys must be Unicode strings)
 * Booleans
 * ``None``
 
@@ -154,16 +155,16 @@ ASGI applications should be a single async callable::
 
     coroutine application(scope, receive, send)
 
-* ``scope``: The Connection Scope, a dictionary that contains at least a
-  ``type`` key specifying the protocol that is incoming.
-* ``receive``, an awaitable callable that will yield a new event dict when
-  one is available
-* ``send``, an awaitable callable taking a single event dict as a
+* ``scope``: The connection scope, a dictionary that contains at least a
+  ``type`` key specifying the protocol that is incoming
+* ``receive``, an awaitable callable that will yield a new event dictionary
+  when one is available
+* ``send``, an awaitable callable taking a single event dictionary as a
   positional argument that will return once the send has been
   completed or the connection has been closed
 
-The application is called once per "connection". What exactly a connection is
-and its lifespan is dictated by the protocol specification in question. For
+The application is called once per "connection." The definition of a connection
+and its lifespan are dictated by the protocol specification in question. For
 example, with HTTP it is one request, whereas for a WebSocket it is a single
 WebSocket connection.
 
@@ -173,8 +174,7 @@ are defined by one of the application protocols. ``scope`` must be a
 be used to work out which protocol is incoming. The key
 ``scope["asgi"]`` will also be present as a dictionary containing a
 ``scope["asgi"]["version"]`` key that corresponds to the ASGI version
-the server implements. If missing the version should default to
-``"2.0"``.
+the server implements. If missing, the version should default to ``"2.0"``.
 
 There may also be a spec-specific version present as
 ``scope["asgi"]["spec_version"]``. This allows the individual protocol
@@ -207,8 +207,8 @@ This style was retired in version 3.0 as the two-callable layout was deemed
 unnecessary. It's now legacy, but there are applications out there written in
 this style, and so it's important to support them.
 
-There is a compatability suite available in the ``asgiref.compatability``
-module which allows you to both detect legacy applications, and convert them
+There is a compatibility suite available in the ``asgiref.compatibility``
+module which allows you to both detect legacy applications and convert them
 to the new single-protocol style seamlessly. Servers are encouraged to support
 both types as of ASGI 3.0 and gradually drop support by default over time.
 
@@ -221,7 +221,7 @@ These describe the standardized scope and message formats for various protocols.
 The one common key across all scopes and messages is ``type``, a way to indicate
 what type of scope or message is being received.
 
-In scopes, the ``type`` key must be a unicode string, like ``"http"`` or
+In scopes, the ``type`` key must be a Unicode string, like ``"http"`` or
 ``"websocket"``, as defined in the relevant protocol specification.
 
 In messages, the ``type`` should be namespaced as ``protocol.message_type``,
@@ -232,9 +232,9 @@ defined by the protocol spec. Examples of a message ``type`` value include
 .. note::
 
   Applications should actively reject any protocol that they do not understand
-  with an Exception (of any type). Failure to do this may result in the server
-  thinking you support a protocol you don't, which can be confusing with
-  the Lifespan protocol, as the server will wait to start until you tell it.
+  with an exception (of any type). Failure to do this may result in the server
+  thinking you support a protocol you don't, which can complicate the Lifespan
+  protocol, as the server will wait to start until you tell it.
 
 
 Current protocol specifications:
@@ -246,42 +246,42 @@ Current protocol specifications:
 Middleware
 ----------
 
-It is possible to have ASGI "middleware" - code that plays the role of both
+It is possible to have ASGI "middleware"---code that plays the role of both
 server and application, taking in a scope and the send/receive awaitables,
 potentially modifying them, and then calling an inner application.
 
 When middleware is modifying the scope, it should make a copy of the scope
-object before mutating it and passing it to the inner application, as otherwise
-changes may leak upstream. In particular, you should not assume that the copy
+object before mutating it and passing it to the inner application, as changes
+may leak upstream otherwise. In particular, you should not assume that the copy
 of the scope you pass down to the application is the one that it ends up using,
 as there may be other middleware in the way; thus, do not keep a reference to
 it and try to mutate it outside of the initial ASGI constructor callable that
-gets passed ``scope``. Your one and only chance to add to it is before you hand
+receives ``scope``. Your one and only chance to add to it is before you hand
 control to the child application.
 
 
 Error Handling
 --------------
 
-If a server receives an invalid event dict - for example, with an unknown type,
-missing keys a type should have, or with wrong Python types for objects (e.g.
-unicode strings for HTTP headers), it should raise an exception out of the
-``send`` awaitable back into the application.
+If a server receives an invalid event dictionary---for example, having an
+unknown ``type``, missing keys an event type should have, or with wrong Python
+types for objects (e.g. Unicode strings for HTTP headers), it should raise an
+exception out of the ``send`` awaitable back to the application.
 
-If an application receives an invalid event dict from ``receive`` it should
-raise an exception.
+If an application receives an invalid event dictionary from ``receive``, it
+should raise an exception.
 
-In both cases, presence of additional keys in the event dict should not raise
-an exception. This is to allow non-breaking upgrades to protocol specifications
-over time.
+In both cases, the presence of additional keys in the event dictionary should
+not raise an exception. This allows non-breaking upgrades to protocol
+specifications over time.
 
 Servers are free to surface errors that bubble up out of application instances
-they are running however they wish - log to console, send to syslog, or other
-options - but they must terminate the application instance and its associated
+they are running however they wish---log to console, send to syslog, or other
+options---but they must terminate the application instance and its associated
 connection if this happens.
 
-Note messages received by a server after the connection has been
-closed are not considered errors. In this case the send awaitable
+Note that messages received by a server after the connection has been
+closed are not considered errors. In this case the ``send`` awaitable
 callable should act as a no-op.
 
 
@@ -306,26 +306,26 @@ There are times when protocol servers may want to provide server-specific
 extensions outside of a core ASGI protocol specification, or when a change
 to a specification is being trialled before being rolled in.
 
-For this use case, we define a common pattern for ``extensions`` - named
+For this use case, we define a common pattern for ``extensions``---named
 additions to a protocol specification that are optional but that, if provided
 by the server and understood by the application, can be used to get more
 functionality.
 
-This is achieved via a ``extensions`` entry in the ``scope`` dict, which is
-itself a dict. Extensions have a unicode string name that
+This is achieved via an ``extensions`` entry in the ``scope`` dictionary, which
+is itself a ``dict``. Extensions have a Unicode string name that
 is agreed upon between servers and applications.
 
 If the server supports an extension, it should place an entry into the
-``extensions`` dict under the extension's name, and the value of that entry
-should itself be a dict. Servers can provide any extra scope information
-that is part of the extension inside this dict value, or if the extension is
-only to indicate that the server accepts additional events via the ``send``
-callable, it may just be an empty dict.
+``extensions`` dictionary under the extension's name, and the value of that
+entry should itself be a ``dict``. Servers can provide any extra scope
+information that is part of the extension inside this value or, if the
+extension is only to indicate that the server accepts additional events via
+the ``send`` callable, it may just be an empty ``dict``.
 
-As an example, imagine a HTTP protocol server wishes to provide an extension
+As an example, imagine an HTTP protocol server wishes to provide an extension
 that allows a new event to be sent back to the server that tries to flush the
 network send buffer all the way through the OS level. It provides an empty
-entry in the extensions dict to signal that it can handle the event::
+entry in the ``extensions`` dictionary to signal that it can handle the event::
 
     scope = {
         "type": "http",
@@ -347,11 +347,11 @@ In this document, and all sub-specifications, *byte string* refers to
 the ``bytes`` type in Python 3. *Unicode string* refers to the ``str`` type
 in Python 3.
 
-This document will never specify just *string* - all strings are one of the
+This document will never specify just *string*---all strings are one of the
 two exact types.
 
-All dict keys mentioned (including those for *scopes* and *events*) are
-unicode strings.
+All ``dict`` keys mentioned (including those for *scopes* and *events*) are
+Unicode strings.
 
 
 Version History

--- a/specs/asgi.rst
+++ b/specs/asgi.rst
@@ -60,7 +60,8 @@ Like WSGI, the server hosts the application inside it, and dispatches incoming
 requests to it in a standardized format. Unlike WSGI, however, applications
 are instantiated objects that are fed events rather than simple callables,
 and must run as ``asyncio``-compatible coroutines (on the main thread;
-they are free to use threading or other processes if they need synchronous code).
+they are free to use threading or other processes if they need synchronous
+code).
 
 Unlike WSGI, there are two separate parts to an ASGI connection:
 
@@ -216,10 +217,11 @@ both types as of ASGI 3.0 and gradually drop support by default over time.
 Protocol Specifications
 -----------------------
 
-These describe the standardized scope and message formats for various protocols.
+These describe the standardized scope and message formats for various
+protocols.
 
-The one common key across all scopes and messages is ``type``, a way to indicate
-what type of scope or message is being received.
+The one common key across all scopes and messages is ``type``, a way to
+indicate what type of scope or message is being received.
 
 In scopes, the ``type`` key must be a Unicode string, like ``"http"`` or
 ``"websocket"``, as defined in the relevant protocol specification.
@@ -232,9 +234,9 @@ defined by the protocol spec. Examples of a message ``type`` value include
 .. note::
 
   Applications should actively reject any protocol that they do not understand
-  with an exception (of any type). Failure to do this may result in the server
-  thinking you support a protocol you don't, which can complicate the Lifespan
-  protocol, as the server will wait to start until you tell it.
+  with an `Exception` (of any type). Failure to do this may result in the
+  server thinking you support a protocol you don't, which can complicate the
+  Lifespan protocol, as the server will wait to start until you tell it.
 
 
 Current protocol specifications:
@@ -322,7 +324,7 @@ information that is part of the extension inside this value or, if the
 extension is only to indicate that the server accepts additional events via
 the ``send`` callable, it may just be an empty ``dict``.
 
-As an example, imagine an HTTP protocol server wishes to provide an extension
+As an example, imagine a HTTP protocol server wishes to provide an extension
 that allows a new event to be sent back to the server that tries to flush the
 network send buffer all the way through the OS level. It provides an empty
 entry in the ``extensions`` dictionary to signal that it can handle the event::

--- a/specs/lifespan.rst
+++ b/specs/lifespan.rst
@@ -5,11 +5,11 @@ Lifespan Protocol
 **Version**: 2.0 (2019-03-20)
 
 The Lifespan ASGI sub-specification outlines how to communicate
-lifespan events such as startup and shutdown within ASGI. The lifespan
-being referred to is that of main event loop. In a multi-process
-environment there will be lifespan events in each process.
+lifespan events such as startup and shutdown within ASGI. This refers to the
+lifespan of the main event loop. In a multi-process environment there will be
+lifespan events in each process.
 
-The lifespan messages allow for a application to initialise and
+The lifespan messages allow for an application to initialise and
 shutdown in the context of a running event loop. An example of this
 would be creating a connection pool and subsequently closing the
 connection pool to release the connections.
@@ -33,7 +33,7 @@ A possible implementation of this protocol is given below::
                         await send({'type': 'lifespan.shutdown.complete'})
                         return
             else:
-                pass # Handle other types
+                pass  # Handle other types
 
         async def startup(self):
             ...
@@ -48,18 +48,19 @@ Scope
 The lifespan scope exists for the duration of the event loop. The
 scope itself contains basic metadata:
 
-* ``type``: ``lifespan``
-* ``asgi["version"]``: The version of the ASGI spec, as a string.
-* ``asgi["spec_version"]``: The version of this spec being used, as a string. Optional, defaults to ``"1.0"``.
+* ``type`` (*Unicode string*): ``"lifespan"``.
+* ``asgi["version"]`` (*Unicode string*): The version of the ASGI spec.
+* ``asgi["spec_version"]`` (*Unicode string*): The version of this spec being
+  used. Optional; defaults to ``"1.0"``.
 
 If an exception is raised when calling the application callable with a
-``lifespan.startup`` message or a scope with type ``lifespan``
+``lifespan.startup`` message or a scope with type ``lifespan``,
 the server must continue but not send any lifespan events.
 
-This allows for compatibility with applications that do not support the lifespan
-protocol. If you want to log an error that occurred during lifespan startup and
-prevent the server from starting, then send back ``lifespan.startup.failed``
-instead.
+This allows for compatibility with applications that do not support the
+lifespan protocol. If you want to log an error that occurs during lifespan
+startup and prevent the server from starting, then send back
+``lifespan.startup.failed`` instead.
 
 
 Startup
@@ -70,7 +71,7 @@ before it has started to do so.
 
 Keys:
 
-* ``type``: ``lifespan.startup``
+* ``type`` (*Unicode string*): ``"lifespan.startup"``.
 
 
 Startup Complete
@@ -81,7 +82,7 @@ must wait for this message before it starts processing connections.
 
 Keys:
 
-* ``type``: ``lifespan.startup.complete``
+* ``type`` (*Unicode string*): ``"lifespan.startup.complete"``.
 
 
 Startup Failed
@@ -92,8 +93,8 @@ sees this it should log/print the message provided and then exit.
 
 Keys:
 
-* ``type``: ``lifespan.startup.failed``
-* ``message``: Unicode string (optional, defaults to ``""``).
+* ``type`` (*Unicode string*): ``"lifespan.startup.failed"``.
+* ``message`` (*Unicode string*): Optional; defaults to ``""``.
 
 
 Shutdown
@@ -104,7 +105,7 @@ active connections.
 
 Keys:
 
-* ``type``:  ``lifespan.shutdown``
+* ``type`` (*Unicode string*):  ``"lifespan.shutdown"``.
 
 
 Shutdown Complete
@@ -115,7 +116,7 @@ must wait for this message before terminating.
 
 Keys:
 
-* ``type``: ``lifespan.shutdown.complete``
+* ``type`` (*Unicode string*): ``"lifespan.shutdown.complete"``.
 
 
 Shutdown Failed
@@ -126,8 +127,8 @@ sees this it should log/print the message provided and then terminate.
 
 Keys:
 
-* ``type``: ``lifespan.shutdown.failed``
-* ``message``: Unicode string (optional, defaults to ``""``).
+* ``type`` (*Unicode string*): ``"lifespan.shutdown.failed"``.
+* ``message`` (*Unicode string*): Optional; defaults to ``""``.
 
 
 Version History

--- a/specs/lifespan.rst
+++ b/specs/lifespan.rst
@@ -48,9 +48,9 @@ Scope
 The lifespan scope exists for the duration of the event loop. The
 scope itself contains basic metadata:
 
-* ``type`` (*Unicode string*): ``"lifespan"``.
-* ``asgi["version"]`` (*Unicode string*): The version of the ASGI spec.
-* ``asgi["spec_version"]`` (*Unicode string*): The version of this spec being
+* ``type`` (*Unicode string*) -- ``"lifespan"``.
+* ``asgi["version"]`` (*Unicode string*) -- The version of the ASGI spec.
+* ``asgi["spec_version"]`` (*Unicode string*) -- The version of this spec being
   used. Optional; defaults to ``"1.0"``.
 
 If an exception is raised when calling the application callable with a
@@ -71,7 +71,7 @@ before it has started to do so.
 
 Keys:
 
-* ``type`` (*Unicode string*): ``"lifespan.startup"``.
+* ``type`` (*Unicode string*) -- ``"lifespan.startup"``.
 
 
 Startup Complete
@@ -82,7 +82,7 @@ must wait for this message before it starts processing connections.
 
 Keys:
 
-* ``type`` (*Unicode string*): ``"lifespan.startup.complete"``.
+* ``type`` (*Unicode string*) -- ``"lifespan.startup.complete"``.
 
 
 Startup Failed
@@ -93,8 +93,8 @@ sees this it should log/print the message provided and then exit.
 
 Keys:
 
-* ``type`` (*Unicode string*): ``"lifespan.startup.failed"``.
-* ``message`` (*Unicode string*): Optional; defaults to ``""``.
+* ``type`` (*Unicode string*) -- ``"lifespan.startup.failed"``.
+* ``message`` (*Unicode string*) -- Optional; defaults to ``""``.
 
 
 Shutdown
@@ -105,7 +105,7 @@ active connections.
 
 Keys:
 
-* ``type`` (*Unicode string*):  ``"lifespan.shutdown"``.
+* ``type`` (*Unicode string*) --  ``"lifespan.shutdown"``.
 
 
 Shutdown Complete
@@ -116,7 +116,7 @@ must wait for this message before terminating.
 
 Keys:
 
-* ``type`` (*Unicode string*): ``"lifespan.shutdown.complete"``.
+* ``type`` (*Unicode string*) -- ``"lifespan.shutdown.complete"``.
 
 
 Shutdown Failed
@@ -127,8 +127,8 @@ sees this it should log/print the message provided and then terminate.
 
 Keys:
 
-* ``type`` (*Unicode string*): ``"lifespan.shutdown.failed"``.
-* ``message`` (*Unicode string*): Optional; defaults to ``""``.
+* ``type`` (*Unicode string*) -- ``"lifespan.shutdown.failed"``.
+* ``message`` (*Unicode string*) -- Optional; defaults to ``""``.
 
 
 Version History

--- a/specs/www.rst
+++ b/specs/www.rst
@@ -176,7 +176,7 @@ Keys:
 Disconnect
 ''''''''''
 
-Sent to the application when an HTTP connection is closed or if ``receive``
+Sent to the application when a HTTP connection is closed or if ``receive``
 is called after a response has been sent. This is mainly useful for
 long-polling, where you may want to trigger cleanup code if the
 connection closes early.

--- a/specs/www.rst
+++ b/specs/www.rst
@@ -20,7 +20,7 @@ This spec has had two versions:
 * ``2.0``: The first version of the spec, released with ASGI 2.0
 * ``2.1``: Added the ``headers`` key to the WebSocket Accept response
 
-Spec versions let you understand what the server you are using understands---if
+Spec versions let you understand what the server you are using understands. If
 a server tells you it only supports version ``2.0`` of this spec, then
 sending ``headers`` with a WebSocket Accept message is an error, for example.
 
@@ -56,7 +56,7 @@ value of ``http``.
 Connection Scope
 ''''''''''''''''
 
-HTTP connections have a single-request connection scope---that is, your
+HTTP connections have a single-request connection scope - that is, your
 applications will be instantiated at the start of the request, and destroyed
 at the end, even if the underlying socket is still open and serving multiple
 requests.
@@ -189,7 +189,7 @@ Keys:
 WebSocket
 ---------
 
-WebSockets share some HTTP details---they have a path and headers---but also
+WebSockets share some HTTP details - they have a path and headers - but also
 have more state. Again, most of that state is in the scope, which will live
 as long as the socket does.
 

--- a/specs/www.rst
+++ b/specs/www.rst
@@ -18,10 +18,10 @@ Spec Versions
 This spec has had two versions:
 
 * ``2.0``: The first version of the spec, released with ASGI 2.0
-* ``2.1``: Added the ``headers`` key to the WebSocket Accept response.
+* ``2.1``: Added the ``headers`` key to the WebSocket Accept response
 
-Spec versions let you understand what the server you are using understands -
-if a server tells you it only supports version ``2.0`` of this spec, then
+Spec versions let you understand what the server you are using understands---if
+a server tells you it only supports version ``2.0`` of this spec, then
 sending ``headers`` with a WebSocket Accept message is an error, for example.
 
 They are separate from the HTTP version or the ASGI version.
@@ -32,8 +32,8 @@ HTTP
 
 The HTTP format covers HTTP/1.0, HTTP/1.1 and HTTP/2, as the changes in
 HTTP/2 are largely on the transport level. A protocol server should give
-different requests on the same HTTP/2 connection different scopes, and
-correctly multiplex the responses back into the same stream as they come in.
+different scopes to different requests on the same HTTP/2 connection, and
+correctly multiplex the responses back to the same stream in which they came.
 The HTTP version is available as a string in the scope.
 
 Multiple header fields with the same name are complex in HTTP. RFC 7230
@@ -56,7 +56,7 @@ value of ``http``.
 Connection Scope
 ''''''''''''''''
 
-HTTP connections have a single-request connection scope - that is, your
+HTTP connections have a single-request connection scope---that is, your
 applications will be instantiated at the start of the request, and destroyed
 at the end, even if the underlying socket is still open and serving multiple
 requests.
@@ -66,44 +66,46 @@ persist until the response closes from either the client or server side.
 
 The connection scope contains:
 
-* ``type``: ``http``
+* ``type`` (*Unicode string*) -- ``"http"``.
 
-* ``asgi["version"]``: The version of the ASGI spec, as a string.
+* ``asgi["version"]`` (*Unicode string*) -- Version of the ASGI spec.
 
-* ``asgi['spec_version']``: Version of the ASGI HTTP spec this server understands
-   as a string; one of ``2.0`` or ``2.1``. Optional, if missing assume ``2.0``.
+* ``asgi["spec_version"]`` (*Unicode string*) -- Version of the ASGI HTTP spec
+  this server understands; one of ``"2.0"`` or ``"2.1"``. Optional; if missing
+  assume ``2.0``.
 
-* ``http_version``: Unicode string, one of ``1.0``, ``1.1`` or ``2``.
+* ``http_version`` (*Unicode string*) -- One of ``"1.0"``, ``"1.1"`` or ``"2"``.
 
-* ``method``: Unicode string HTTP method name, uppercased.
+* ``method`` (*Unicode string*) -- The HTTP method name, uppercased.
 
-* ``scheme``: Unicode string URL scheme portion (likely ``http`` or ``https``).
-  Optional (but must not be empty), default is ``"http"``.
+* ``scheme`` (*Unicode string*) -- URL scheme portion (likely ``"http"`` or
+  ``"https"``). Optional (but must not be empty); default is ``"http"``.
 
-* ``path``: Unicode string HTTP request target excluding any query
-  string, with percent escapes decoded and UTF-8 byte sequences
+* ``path`` (*Unicode string*) -- HTTP request target excluding any query
+  string, with percent-encoded sequences and UTF-8 byte sequences
   decoded into characters.
 
-* ``query_string``: Byte string URL portion after the ``?``, not url-decoded.
+* ``query_string`` (*byte string*) -- URL portion after the ``?``,
+  percent-encoded.
 
-* ``root_path``: Unicode string that indicates the root path this application
-  is mounted at; same as ``SCRIPT_NAME`` in WSGI. Optional, defaults
+* ``root_path`` (*Unicode string*) -- The root path this application
+  is mounted at; same as ``SCRIPT_NAME`` in WSGI. Optional; defaults
   to ``""``.
 
-* ``headers``: An iterable of ``[name, value]`` two-item iterables, where
-  ``name`` is the byte string header name, and ``value`` is the byte string
-  header value. Order of header values must be preserved from the original HTTP
-  request; order of header names is not important. Duplicates are possible and
-  must be preserved in the message as received.
+* ``headers`` (*Iterable[[byte string, byte string]]*) -- An iterable of
+  ``[name, value]`` two-item iterables, where ``name`` is the header name, and
+  ``value`` is the header value. Order of header values must be preserved from
+  the original HTTP request; order of header names is not important. Duplicates
+  are possible and must be preserved in the message as received.
   Header names must be lowercased.
 
-* ``client``: A two-item iterable of ``[host, port]``, where ``host``
-  is a unicode string of the remote host's IPv4 or IPv6 address, and
-  ``port`` is the remote port as an integer. Optional, defaults to ``None``.
+* ``client`` (*Iterable[Unicode string, int]*) -- A two-item iterable of
+  ``[host, port]``, where ``host`` the remote host's IPv4 or IPv6 address, and
+  ``port`` is the remote port as an integer. Optional; defaults to ``None``.
 
-* ``server``: A two-item iterable of ``[host, port]``, where ``host``
-  is the listening address for this server as a unicode string, and ``port``
-  is the integer listening port. Optional, defaults to ``None``.
+* ``server`` (*Iterable[Unicode string, int]*) -- A two-item iterable of
+  ``[host, port]``, where ``host`` is the listening address for this server,
+  and ``port`` is the integer listening port. Optional; defaults to ``None``.
 
 
 Request
@@ -116,17 +118,17 @@ should not trigger on a connection opening alone).
 
 Keys:
 
-* ``type``: ``http.request``
+* ``type`` (*Unicode string*) -- ``"http.request"``.
 
-* ``body``: Body of the request, as a byte string. Optional, defaults to ``b""``.
-  If ``more_body`` is set, treat as start of body and concatenate
+* ``body`` (*byte string*) -- Body of the request. Optional; defaults to
+  ``b""``. If ``more_body`` is set, treat as start of body and concatenate
   on further chunks.
 
-* ``more_body``: Boolean value signifying if there is additional content
+* ``more_body`` (*bool*) -- Signifies if there is additional content
   to come (as part of a Request message). If ``True``, the consuming
   application should wait until it gets a chunk with this set to ``False``. If
-  ``False``, the request is complete and should be processed. Optional, defaults
-  to ``False``.
+  ``False``, the request is complete and should be processed. Optional;
+  defaults to ``False``.
 
 
 Response Start
@@ -134,18 +136,19 @@ Response Start
 
 Starts sending a response to the client. Needs to be followed by at least
 one response content message. The protocol server must not start sending the
-response to the client until it has received at least one *Response Body* event.
+response to the client until it has received at least one *Response Body*
+event.
 
 Keys:
 
-* ``type``: ``http.response.start``
+* ``type`` (*Unicode string*) -- ``"http.response.start"``.
 
-* ``status``: Integer HTTP status code.
+* ``status`` (*int*) -- HTTP status code.
 
-* ``headers``: A list of ``[name, value]`` lists, where ``name`` is the
-  byte string header name, and ``value`` is the byte string
-  header value. Order must be preserved in the HTTP response. Header names
-  must be lowercased. Optional, defaults to an empty list.
+* ``headers`` (*Iterable[[byte string, byte string]]*) -- A iterable of
+  ``[name, value]`` two-item iterables, where ``name`` is the header name, and
+  ``value`` is the header value. Order must be preserved in the HTTP response.
+  Header names must be lowercased. Optional; defaults to an empty list.
 
 
 Response Body
@@ -158,35 +161,35 @@ close the connection.
 
 Keys:
 
-* ``type``: ``http.response.body``
+* ``type`` (*Unicode string*) -- ``"http.response.body"``.
 
-* ``body``: Byte string of HTTP body content. Concatenated onto any previous
-  ``body`` values sent in this connection scope. Optional, defaults to
+* ``body`` (*byte string*) -- HTTP body content. Concatenated onto any previous
+  ``body`` values sent in this connection scope. Optional; defaults to
   ``b""``.
 
-* ``more_body``: Boolean value signifying if there is additional content
+* ``more_body`` (*bool*) -- Signifies if there is additional content
   to come (as part of a Response Body message). If ``False``, response will
-  be taken as complete and closed off, and any further messages on the channel
-  will be ignored. Optional, defaults to ``False``.
+  be taken as complete and closed, and any further messages on the channel
+  will be ignored. Optional; defaults to ``False``.
 
 
 Disconnect
 ''''''''''
 
-Sent to the application when a HTTP connection is closed or if receive
+Sent to the application when an HTTP connection is closed or if ``receive``
 is called after a response has been sent. This is mainly useful for
 long-polling, where you may want to trigger cleanup code if the
 connection closes early.
 
 Keys:
 
-* ``type``: ``http.disconnect``
+* ``type`` (*Unicode string*) -- ``"http.disconnect"``.
 
 
 WebSocket
 ---------
 
-WebSockets share some HTTP details - they have a path and headers - but also
+WebSockets share some HTTP details---they have a path and headers---but also
 have more state. Again, most of that state is in the scope, which will live
 as long as the socket does.
 
@@ -207,46 +210,47 @@ WebSocket connections' scope lives as long as the socket itself - if the
 application dies the socket should be closed, and vice-versa. The scope
 contains the initial connection metadata (mostly from the HTTP handshake):
 
-* ``type``: ``websocket``
+* ``type`` (*Unicode string*) -- ``"websocket"``.
 
-* ``asgi["version"]``: The version of the ASGI spec, as a string.
+* ``asgi["version"]`` (*Unicode string*) -- The version of the ASGI spec.
 
-* ``asgi['spec_version']``: Version of the ASGI HTTP spec this server understands
-   as a string; one of ``2.0`` or ``2.1``. Optional, if missing assume ``2.0``.
+* ``asgi["spec_version"]`` (*Unicode string*) -- Version of the ASGI HTTP spec
+  this server understands; one of ``"2.0"`` or ``"2.1"``. Optional; if missing
+  assume ``"2.0"``.
 
-* ``http_version``: Unicode string, one of ``1.1`` or ``2``. Optional,
-  default is ``1.1``.
+* ``http_version`` (*Unicode string*) -- One of ``"1.1"`` or ``"2"``. Optional;
+  default is ``"1.1"``.
 
-* ``scheme``: Unicode string URL scheme portion (likely ``ws`` or ``wss``).
-  Optional (but must not be empty), default is ``ws``.
+* ``scheme`` (*Unicode string*) -- URL scheme portion (likely ``"ws"`` or
+  ``"wss"``). Optional (but must not be empty); default is ``"ws"``.
 
-* ``path``: Unicode string HTTP request target excluding any query
-  string, with percent escapes decoded and UTF-8 byte sequences
+* ``path`` (*Unicode string*) -- HTTP request target excluding any query
+  string, with percent-encoded sequences and UTF-8 byte sequences
   decoded into characters.
 
-* ``query_string``: Byte string URL portion after the ``?``. Optional, default
-  is empty string.
+* ``query_string`` (*byte string*) -- URL portion after the ``?``. Optional;
+  default is empty string.
 
-* ``root_path``: Byte string that indicates the root path this application
-  is mounted at; same as ``SCRIPT_NAME`` in WSGI. Optional, defaults
+* ``root_path`` (*byte string*) -- The root path this application
+  is mounted at; same as ``SCRIPT_NAME`` in WSGI. Optional; defaults
   to empty string.
 
-* ``headers``: An iterable of ``[name, value]`` two-item iterables, where
-  ``name`` is the header name as byte string and ``value`` is the header value
-  as a byte string. Order should be preserved from the original HTTP request;
-  duplicates are possible and must be preserved in the message as received.
-  Header names must be lowercased.
+* ``headers`` (*Iterable[[byte string, byte string]]*) -- An iterable of
+  ``[name, value]`` two-item iterables, where ``name`` is the header name and
+  ``value`` is the header value. Order should be preserved from the original
+  HTTP request; duplicates are possible and must be preserved in the message
+  as received. Header names must be lowercased.
 
-* ``client``: A two-item iterable of ``[host, port]``, where ``host``
-  is a unicode string of the remote host's IPv4 or IPv6 address, and
-  ``port`` is the remote port as an integer. Optional, defaults to ``None``.
+* ``client`` (*Iterable[Unicode string, int]*) -- A two-item iterable of
+  ``[host, port]``, where ``host`` is the remote host's IPv4 or IPv6 address,
+  and ``port`` is the remote port. Optional; defaults to ``None``.
 
-* ``server``: A two-item iterable of ``[host, port]``, where ``host``
-  is the listening address for this server as a unicode string, and ``port``
-  is the integer listening port. Optional, defaults to ``None``.
+* ``server`` (*Iterable[Unicode string, int]*) -- A two-item iterable of
+  ``[host, port]``, where ``host`` is the listening address for this server,
+  and ``port`` is the integer listening port. Optional; defaults to ``None``.
 
-* ``subprotocols``: List of subprotocols the client advertised as unicode
-  strings. Optional, defaults to empty list.
+* ``subprotocols`` (*Iterable[Unicode string]*) -- Subprotocols the client
+  advertised. Optional; defaults to empty list.
 
 
 Connection
@@ -264,7 +268,7 @@ denied.
 
 Keys:
 
-* ``type``: ``websocket.connect``
+* ``type`` (*Unicode string*) -- ``"websocket.connect"``.
 
 
 Accept
@@ -272,17 +276,17 @@ Accept
 
 Sent by the application when it wishes to accept an incoming connection.
 
-* ``type``: ``websocket.accept``
+* ``type`` (*Unicode string*) -- ``"websocket.accept"``.
 
-* ``subprotocol``: The subprotocol the server wishes to accept, as a unicode
-  string. Optional, defaults to ``None``.
+* ``subprotocol`` (*Unicode string*) -- The subprotocol the server wishes to
+  accept. Optional; defaults to ``None``.
 
-* ``headers``: A list of ``[name, value]`` lists, where ``name`` is
-  the byte string header name, and ``value`` is the byte string header
-  value. Order must be preserved in the HTTP response. Header names
-  must be lowercased. Must not include a ``sec-websocket-protocol``
-  named header, use the ``subprotocol`` key instead.  Optional,
-  defaults to an empty list. *Added in spec version 2.1*
+* ``headers`` (*Iterable[[byte string, byte string]]*) -- An iterable of
+  ``[name, value]`` two-item iterables, where ``name`` is the header name, and
+  ``value`` is the header value. Order must be preserved in the HTTP response.
+  Header names must be lowercased. Must not include a header named
+  ``sec-websocket-protocol``; use the ``subprotocol`` key instead. Optional;
+  defaults to an empty list. *Added in spec version 2.1*.
 
 
 Receive
@@ -292,12 +296,12 @@ Sent when a data message is received from the client.
 
 Keys:
 
-* ``type``: ``websocket.receive``
+* ``type`` (*Unicode string*) -- ``"websocket.receive"``.
 
-* ``bytes``: Byte string of the message content, if it was binary mode, or
+* ``bytes`` (*byte string*) -- The message content, if it was binary mode, or
   ``None``. Optional; if missing, it is equivalent to ``None``.
 
-* ``text``: Unicode string of the message content, if it was text mode, or
+* ``text`` (*Unicode string*) -- The message content, if it was text mode, or
   ``None``. Optional; if missing, it is equivalent to ``None``.
 
 Exactly one of ``bytes`` or ``text`` must be non-``None``. One or both
@@ -311,12 +315,12 @@ Sends a data message to the client.
 
 Keys:
 
-* ``type``: ``websocket.send``
+* ``type`` (*Unicode string*) -- ``"websocket.send"``.
 
-* ``bytes``: Byte string of binary message content, or ``None``.
+* ``bytes`` (*byte string*) -- Binary message content, or ``None``.
    Optional; if missing, it is equivalent to ``None``.
 
-* ``text``: Unicode string of text message content, or ``None``.
+* ``text`` (*Unicode string*) -- Text message content, or ``None``.
    Optional; if missing, it is equivalent to ``None``.
 
 Exactly one of ``bytes`` or ``text`` must be non-``None``. One or both
@@ -332,9 +336,9 @@ socket.
 
 Keys:
 
-* ``type``: ``websocket.disconnect``
+* ``type`` (*Unicode string*) -- ``"websocket.disconnect"``
 
-* ``code``: The WebSocket close code (integer), as per the WebSocket spec.
+* ``code`` (*int*) -- The WebSocket close code, as per the WebSocket spec.
 
 
 Close
@@ -350,10 +354,10 @@ browsers as a different WebSocket error code (such as 1006, Abnormal Closure).
 If this is sent after the socket is accepted, the server must close the socket
 with the close code passed in the message (or 1000 if none is specified).
 
-* ``type``: ``websocket.close``
+* ``type`` (*Unicode string*) -- ``"websocket.close"``.
 
-* ``code``: The WebSocket close code (integer), as per the WebSocket spec.
-  Optional, defaults to ``1000``.
+* ``code`` (*int*) -- The WebSocket close code, as per the WebSocket spec.
+  Optional; defaults to ``1000``.
 
 
 WSGI Compatibility
@@ -371,7 +375,7 @@ lifetime.
 There is an almost direct mapping for the various special keys in
 WSGI's ``environ`` variable to the ``http`` scope:
 
-* ``REQUEST_METHOD`` is the ``method`` key
+* ``REQUEST_METHOD`` is the ``method``
 * ``SCRIPT_NAME`` is ``root_path``
 * ``PATH_INFO`` can be derived from ``path`` and ``root_path``
 * ``QUERY_STRING`` is ``query_string``
@@ -381,7 +385,7 @@ WSGI's ``environ`` variable to the ``http`` scope:
 * ``REMOTE_HOST``/``REMOTE_ADDR`` and ``REMOTE_PORT`` are in ``client``
 * ``SERVER_PROTOCOL`` is encoded in ``http_version``
 * ``wsgi.url_scheme`` is ``scheme``
-* ``wsgi.input`` is a StringIO based around the ``http.request`` messages
+* ``wsgi.input`` is a ``StringIO`` based around the ``http.request`` messages
 * ``wsgi.errors`` is directed by the wrapper as needed
 
 The ``start_response`` callable maps similarly to ``http.response.start``:
@@ -402,24 +406,25 @@ codepoints in the ISO-8859-1 ("latin-1") range. This was due to it originally
 being designed for Python 2 and its different set of string types.
 
 The ASGI HTTP and WebSocket specifications instead specify each entry of the
-``scope`` dict as either a bytestring or a unicode string. HTTP, being an older
-protocol, is sometimes imperfect at specifying encoding, so some decisions
-of what is unicode versus bytes may not be obvious.
+``scope`` dict as either a byte string or a Unicode string. HTTP, being an
+older protocol, is sometimes imperfect at specifying encoding, so some
+decisions of what is Unicode versus bytes may not be obvious.
 
 * ``path``: URLs can have both percent-encoded and UTF-8 encoded sections.
   Because decoding these is often done by the underlying server (or sometimes
-  even proxies in the path), this is a unicode string, fully decoded from both
+  even proxies in the path), this is a Unicode string, fully decoded from both
   UTF-8 encoding and percent encodings.
 
-* ``headers``: These are bytestrings of the exact byte sequences sent by the
+* ``headers``: These are byte strings of the exact byte sequences sent by the
   client/to be sent by the server. While modern HTTP standards say that headers
   should be ASCII, older ones did not and allowed a wider range of characters.
   Frameworks/applications should decode headers as they deem appropriate.
 
 * ``query_string``: Unlike the ``path``, this is not as subject to server
-  interference and so is presented as its raw bytestring version, undecoded.
+  interference and so is presented as its raw byte string version,
+  percent-encoded.
 
-* ``root_path``: Unicode to match ``path``.
+* ``root_path``: Unicode string to match ``path``.
 
 
 Version History


### PR DESCRIPTION
Hey folks, I'm keen on making myself useful toward getting ASGI into Django (I talked with @andrewgodwin at DjangoCon US 2018 about it and recently saw @tomchristie's DjangoCon EU 2019 keynote) and I'm starting pretty well from scratch by reading the ASGI specification docs. Since I've just gone through the thing, I wanted to contribute some clarifying changes to things that tripped me up that I hope will provide some value to others.

The biggest change was moving data types for protocol specifications to a consistent place for better readability, e.g.:

### Before

* `type`: `http`
* `asgi["version"]`: The version of the ASGI spec, as a string

### After

* `type` (_Unicode string_) – `"http"`
* `asgi["version"]` (_Unicode string_) – Version of the ASGI spec

The rest being mostly minor stuff for consistency:

* Fix a few typographical errors, punctuation, etc.
* Rephrase a few passages for clarity
* Use consistent capitalization of "Unicode"
* Use consistent phrasing for "percent encoding"
* Change double-negative "not decoded"/"not unencoded" to "encoded"

Hope this helps; I'll be reading more on Starlette, uvicorn, etc. as well as Django roadmap stuff where I can, and if there are any specific areas you need help with presently please don't hesitate to let me know. Cheers!