### PR TITLE
Fix and document docs process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,36 @@ Contributing
 Please refer to the
 `main Channels contributing docs <https://github.com/django/channels/blob/master/CONTRIBUTING.rst>`_.
 
+
+Testing
+'''''''
+
 To run tests, make sure you have installed the ``tests`` extra with the package::
 
     cd asgiref/
     pip install -e .[tests]
     pytest
+
+
+Building the documentation
+'''''''''''''''''''''''''
+
+The documentation uses `Sphinx <http://www.sphinx-doc.org>`_::
+
+    cd asgiref/docs/
+    pip install sphinx
+
+To build the docs, you can use the default tools::
+
+    sphinx-build -b html . _build/html  # or `make html`, if you've got make set up
+    cd _build/html
+    python -m http.server
+
+...or you can use ``sphinx-autobuild`` to run a server and rebuild/reload
+your documentation changes automatically::
+
+    pip install sphinx-autobuild
+    sphinx-autobuild . _build/html
 
 
 Maintenance and Security

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,15 +101,15 @@ html_static_path = ['_static']
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-        'about.html',
-        'navigation.html',
-        'relations.html',
-        'searchbox.html',
-        'donate.html',
-    ]
-}
+# html_sidebars = {
+#     '**': [
+#         'about.html',
+#         'navigation.html',
+#         'relations.html',
+#         'searchbox.html',
+#         'donate.html',
+#     ]
+# }
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
Resolves #84 

* Comment out `html_sidebars` lines from `docs/conf.py` to get default working Sphinx theme when building docs out of the box
* Add section in `README.rst` about how to build the docs (this can go somewhere else if it's starting to feel lengthy?)