### PR TITLE
[WIP/RFC] SyncToAsync: use executor attribute

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -179,6 +179,7 @@ class SyncToAsync:
     with a CurrentThreadExecutor while AsyncToSync is blocking its sync parent,
     rather than just blocking.
     """
+
     executor = None
 
     # Maps launched threads to the coroutines that spawned them
@@ -200,16 +201,11 @@ class SyncToAsync:
             pass
 
         if self.__class__.executor is None:
+            executor_kwargs = {}
             if "ASGI_THREADS" in os.environ:
-                executor_kwargs = {
-                    "max_workers": int(os.environ["ASGI_THREADS"]),
-                }
-            else:
-                executor_kwargs = {}
-
+                executor_kwargs["max_workers"] = int(os.environ["ASGI_THREADS"])
             if sys.version_info >= (3, 6):
                 executor_kwargs["thread_name_prefix"] = "sync_to_async"
-
             self.__class__.executor = ThreadPoolExecutor(**executor_kwargs)
 
     async def __call__(self, *args, **kwargs):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -58,9 +58,15 @@ async def test_sync_to_async_ASGI_THREADS(monkeypatch):
     # It should take at least 1 second as there's only one worker.
     assert end - start >= 1
 
+    # Uses existing executor instance on class.
     monkeypatch.setenv("ASGI_THREADS", 99)
+    orig_executor = async_function.executor
     async_function = sync_to_async(sync_function)
-    assert async_function.executor._max_workers == 1
+    assert async_function.executor is orig_executor
+
+    monkeypatch.setattr(sync_to_async, "executor", None)
+    async_function = sync_to_async(sync_function)
+    assert async_function.executor is not orig_executor
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This allows for overriding it easily in derived classes, and it seems to
be better than changing the loop's default executor (in the case of
ASGI_THREADS being set).

Ref: https://github.com/django/channels/issues/1091