### PR TITLE
pytest: use testpaths instead of addopts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal=1
 
 [tool:pytest]
-addopts = tests/
+testpaths = tests
 
 [flake8]
 exclude = venv/*,tox/*,specs/*


### PR DESCRIPTION
Nobody is using test selection?!