### PR TITLE
Fixed unittest collection with @async_to_sync on Python 3.7.

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -82,7 +82,8 @@ class AsyncToSync:
         """
         Include self for methods
         """
-        return functools.partial(self.__call__, parent)
+        func = functools.partial(self.__call__, parent)
+        return functools.update_wrapper(func, self.awaitable)
 
     async def main_wrap(self, args, kwargs, call_result, source_thread):
         """

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,7 @@ import asyncio
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from unittest import TestCase
 
 import pytest
 
@@ -194,3 +195,11 @@ def test_async_to_sync_in_thread():
 
     # Run it
     assert result["worked"]
+
+
+
+class ASGITest(TestCase):
+
+    @async_to_sync
+    async def test_wrapped_case_is_collected(self):
+        self.assertTrue(True)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -197,9 +197,7 @@ def test_async_to_sync_in_thread():
     assert result["worked"]
 
 
-
 class ASGITest(TestCase):
-
     @async_to_sync
     async def test_wrapped_case_is_collected(self):
         self.assertTrue(True)


### PR DESCRIPTION
Closes #103. 

Test case reproducing issue locally. Passes on py36. Fails on py37. Seeing how it goes on Travis. 

Update: fix added. 