### PR TITLE
Copy method's __self__ in sync_to_async

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -198,6 +198,10 @@ class SyncToAsync:
     def __init__(self, func, thread_sensitive=False):
         self.func = func
         self._thread_sensitive = thread_sensitive
+        try:
+            self.__self__ = func.__self__
+        except AttributeError:
+            pass
 
     async def __call__(self, *args, **kwargs):
         loop = asyncio.get_event_loop()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -78,6 +78,28 @@ async def test_sync_to_async_method_decorator():
 
 
 @pytest.mark.asyncio
+async def test_sync_to_async_method_self_attribute():
+    """
+    Tests sync_to_async on a method copies __self__
+    """
+
+    # Define sync function
+    class TestClass:
+        def test_method(self):
+            time.sleep(0.1)
+            return 45
+
+    # Check it works right
+    instance = TestClass()
+    method = sync_to_async(instance.test_method)
+    result = await method()
+    assert result == 45
+
+    # Check __self__ has been copied
+    assert method.__self__ == instance
+
+
+@pytest.mark.asyncio
 async def test_async_to_sync_to_async():
     """
     Tests we can call async functions from a sync thread created by async_to_sync


### PR DESCRIPTION
This change is needed to fix a test failure (test_process_template_response_returns_none) in andrewgodwin/django on async_views branch.