### PR TITLE
Allow an application to instruct the server to shutdown

### DIFF
--- a/specs/lifespan.rst
+++ b/specs/lifespan.rst
@@ -92,6 +92,9 @@ Shutdown
 Sent when the server has stopped accepting connections and closed all
 active connections.
 
+Alternatively this is sent by the application when it wants the server
+to gracefully shutdown.
+
 Keys:
 
 * ``type`` (*Unicode string*) --  ``"lifespan.shutdown"``.
@@ -123,6 +126,8 @@ Keys:
 Version History
 ===============
 
+* 3.0 (2019-08-11): Allow applications to send ``lifespan.shutdown``
+  messages to a server to initiate shutdown of the server.
 * 2.0 (2019-03-04): Added startup.failed and shutdown.failed,
   clarified exception handling during startup phase.
 * 1.0 (2018-09-06): Updated ASGI spec with a lifespan protocol.


### PR DESCRIPTION
This adds to the lifespan specification that the lifespan.shutdown
message may also be sent from the application to the server to trigger
a graceful shutdown.

This is something I've been asked about, in https://github.com/pgjones/quart/issues/76, and something that seems to be supported in some WSGI servers, [Werkzeug](https://werkzeug.palletsprojects.com/en/0.14.x/serving/#shutting-down-the-server).