### PR TITLE
Make WsgiToAsgi pass SERVER_PORT as a string

### DIFF
--- a/asgiref/wsgi.py
+++ b/asgiref/wsgi.py
@@ -61,10 +61,10 @@ class WsgiToAsgiInstance:
         # Get server name and port - required in WSGI, not in ASGI
         if "server" in scope:
             environ["SERVER_NAME"] = scope["server"][0]
-            environ["SERVER_PORT"] = scope["server"][1]
+            environ["SERVER_PORT"] = str(scope["server"][1])
         else:
             environ["SERVER_NAME"] = "localhost"
-            environ["SERVER_PORT"] = 80
+            environ["SERVER_PORT"] = "80"
 
         if "client" in scope:
             environ["REMOTE_ADDR"] = scope["client"][0]


### PR DESCRIPTION
WSGI applications expect to receive SERVER_PORT as a string, whereas
ASGI defines `server` as a (str, int) tuple.

This for example trips up werkzeug:

```
  File "venv/lib/python3.7/site-packages/werkzeug/wsgi.py", line 174, in get_host
    rv += ":" + environ["SERVER_PORT"]
TypeError: can only concatenate str (not "int") to str
```