### PR TITLE
Make WsgiToAsgi check scope type

### DIFF
--- a/asgiref/wsgi.py
+++ b/asgiref/wsgi.py
@@ -30,6 +30,8 @@ class WsgiToAsgiInstance:
         self.response_started = False
 
     async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            raise ValueError("WSGI wrapper received a non-HTTP scope")
         self.scope = scope
         # Alright, wait for the http.request message
         message = await receive()


### PR DESCRIPTION
Currently, we validate that messages are of type "http.request". However
this validation only occurs when the first message is received. This may
be too late for servers (such as hypercorn) which try to determine
support for the lifespan extension.

This change checks that scope["type"] is "http" to provide early
failure.