### PR TITLE
Made AsgiToWsgi pass root_path as SCRIPT_NAME

### DIFF
--- a/asgiref/wsgi.py
+++ b/asgiref/wsgi.py
@@ -48,7 +48,7 @@ class WsgiToAsgiInstance:
         """
         environ = {
             "REQUEST_METHOD": scope["method"],
-            "SCRIPT_NAME": "",
+            "SCRIPT_NAME": scope.get("root_path", ""),
             "PATH_INFO": scope["path"],
             "QUERY_STRING": scope["query_string"].decode("ascii"),
             "SERVER_PROTOCOL": "HTTP/%s" % scope["http_version"],


### PR DESCRIPTION
In order to properly support applications which are not mounted at the
root, we need to pass the ASGI `root_path` as the WSGI `SCRIPT_NAME`.