### PR TITLE
Include regression tests in MANIFEST.in to include them in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+recursive-include tests *.py


### PR DESCRIPTION
In OpenBSD we like to gave the regression tests for testing and making sure we haven't broken things when updating other ports. 

This will include those tests in the PyPI tarball for future releases.