### PR TITLE
Fix headers example in introduction

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -57,7 +57,7 @@ response that you might get from ``receive``::
     {
         "type": "http.response.start",
         "status": 200,
-        "headers": [b"X-Header", b"Amazing Value"],
+        "headers": [[b"X-Header", b"Amazing Value"]],
     }
 
 And here's an example of an event you might pass to ``send`` to send an

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -57,7 +57,7 @@ response that you might get from ``receive``::
     {
         "type": "http.response.start",
         "status": 200,
-        "headers": [[b"X-Header", b"Amazing Value"]],
+        "headers": [(b"X-Header", b"Amazing Value")],
     }
 
 And here's an example of an event you might pass to ``send`` to send an


### PR DESCRIPTION
As per [spec](https://asgi.readthedocs.io/en/latest/specs/www.html#response-start), this should be a list of two-lists