### PR TITLE
Fixed #132 -- Set explicit loop policy for Windows & Python 3.8.

### DIFF
--- a/asgiref/__init__.py
+++ b/asgiref/__init__.py
@@ -1,1 +1,9 @@
+import asyncio
+import sys
+
 __version__ = "3.2.2"
+
+
+# Avoid issue #132 on Windows & Python 3.8.
+if sys.platform == "win32" and sys.version_info >= (3, 8, 0):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
Not 100% convinced about this, but it allows both the `asgiref` and Django test suites to pass on Windows with Python 3.8, so I thought I'd open the PR.

Once fixed in Python, I'd imagine replacing this with a warning to upgrade to whatever point release fixes it. CPython issue: https://bugs.python.org/issue38563

I went for `__init__.py` as the earliest entry point, but open to any better suggestions. 