### PR TITLE
Declare python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
+    python_requires=">=3.5",
     extras_require={
         "tests": [
             "pytest~=4.3.0",


### PR DESCRIPTION
This will prevent installation on unsupported Python versions.