### PR TITLE
Cancel and wait for tasks before asyncgen shutdown.

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -124,6 +124,21 @@ class AsyncToSync:
             loop.run_until_complete(coro)
         finally:
             try:
+                # mimic asyncio.run() behavior
+                # cancel unexhausted async generators
+                tasks = asyncio.all_tasks(loop)
+                for task in tasks:
+                    task.cancel()
+                loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
+                for task in tasks:
+                    if task.cancelled():
+                        continue
+                    if task.exception() is not None:
+                        loop.call_exception_handler({
+                            'message': 'unhandled exception during loop shutdown',
+                            'exception': task.exception(),
+                            'task': task
+                        })
                 if hasattr(loop, "shutdown_asyncgens"):
                     loop.run_until_complete(loop.shutdown_asyncgens())
             finally:

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -138,7 +138,7 @@ class AsyncToSync:
                             {
                                 "message": "unhandled exception during loop shutdown",
                                 "exception": task.exception(),
-                                "task": task
+                                "task": task,
                             }
                         )
                 if hasattr(loop, "shutdown_asyncgens"):

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -134,11 +134,13 @@ class AsyncToSync:
                     if task.cancelled():
                         continue
                     if task.exception() is not None:
-                        loop.call_exception_handler({
-                            'message': 'unhandled exception during loop shutdown',
-                            'exception': task.exception(),
-                            'task': task
-                        })
+                        loop.call_exception_handler(
+                            {
+                                'message': 'unhandled exception during loop shutdown',
+                                'exception': task.exception(),
+                                'task': task
+                            }
+                        )
                 if hasattr(loop, "shutdown_asyncgens"):
                     loop.run_until_complete(loop.shutdown_asyncgens())
             finally:

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -136,9 +136,9 @@ class AsyncToSync:
                     if task.exception() is not None:
                         loop.call_exception_handler(
                             {
-                                'message': 'unhandled exception during loop shutdown',
-                                'exception': task.exception(),
-                                'task': task
+                                "message": "unhandled exception during loop shutdown",
+                                "exception": task.exception(),
+                                "task": task
                             }
                         )
                 if hasattr(loop, "shutdown_asyncgens"):

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -126,7 +126,7 @@ class AsyncToSync:
             try:
                 # mimic asyncio.run() behavior
                 # cancel unexhausted async generators
-                tasks = asyncio.all_tasks(loop)
+                tasks = asyncio.Task.all_tasks(loop)
                 for task in tasks:
                     task.cancel()
                 loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))


### PR DESCRIPTION
`asyncio.all_tasks()` first appeared in Python 3.7. I am not familiar with what syntax changes would be necessary to support Python 3.5.