### PR TITLE
[RFC] Propagate changes to contextvars "upstream" for SyncToAsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 .cache
 .eggs
 .python-version
+.pytest_cache/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 *~
 .cache
 .eggs
+.python-version

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -265,7 +265,10 @@ class SyncToAsync:
             # Check for changes in contextvars, and set them to the current
             # context for downstream consumers
             for cvar in context:
-                if cvar.get() != context.get(cvar):
+                try:
+                    if cvar.get() != context.get(cvar):
+                        cvar.set(context.get(cvar))
+                except LookupError:
                     cvar.set(context.get(cvar))
 
         return ret

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -259,7 +259,16 @@ class SyncToAsync:
                 **kwargs
             ),
         )
-        return await asyncio.wait_for(future, timeout=None)
+        ret = await asyncio.wait_for(future, timeout=None)
+
+        if contextvars is not None:
+            # Check for changes in contextvars, and set them to the current
+            # context for downstream consumers
+            for cvar in context:
+                if cvar.get() != context.get(cvar):
+                    cvar.set(context.get(cvar))
+
+        return ret
 
     def __get__(self, parent, objtype):
         """

--- a/tests/test_sync_contextvars.py
+++ b/tests/test_sync_contextvars.py
@@ -1,0 +1,31 @@
+import time
+
+import pytest
+
+from asgiref.sync import sync_to_async
+
+contextvars = pytest.importorskip("contextvars")
+
+foo = contextvars.ContextVar("foo")
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_contextvars():
+    """
+    Tests to make sure that contextvars from the calling context are
+    present in the called context, and that any changes in the called context
+    are then propagated back to the calling context.
+    """
+    # Define sync function
+    def sync_function():
+        time.sleep(1)
+        assert foo.get() == "bar"
+        foo.set("baz")
+        return 42
+
+    # Ensure outermost detection works
+    # Wrap it
+    foo.set("bar")
+    async_function = sync_to_async(sync_function)
+    await async_function()
+    assert foo.get() == "baz"


### PR DESCRIPTION
This PR changes `SyncToAsync` to check if downstream code made changes to any contextvars, and propagates those changes back to the current context, so they'll be available for future downstream consumers.

### Background

I work on Elastic's APM team, and our [python agent](https://github.com/elastic/apm-agent-python) uses `contextvars` to keep track of the running transaction object during a request in Django. We create that transaction object [in our `request_started` signal handler](https://github.com/elastic/apm-agent-python/blob/11c64362fe5189ee30936eb8791b8e1368371dd0/elasticapm/contrib/django/apps.py#L147). The reason we do it there instead of in our middleware is so we can measure time spent in the resolver and any middleware that execute before ours.

However, for ASGI, that transaction is no longer present in `contextvars` because it is set in the [copy](https://github.com/django/asgiref/blob/911215ca81a6956df4de7e282f954654443b1fcd/asgiref/sync.py#L241) that `SyncToAsync` provides to the executor. ([PR where this was added](https://github.com/django/asgiref/pull/73))

This PR checks for any changes to the context made by the downstream code, and calls `.set()` for each of these `ContextVar` instances so those changes are "saved" for future downstream calls.

***

I ran the tests and everything passed. I can't think of any adverse side effects from this change, but I'm fairly new to ASGI in Django, thus the `[RFC]`. Thanks in advance for your comments!