### PR TITLE
Copied method's __self__ in async_to_sync.

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -37,6 +37,10 @@ class AsyncToSync:
 
     def __init__(self, awaitable, force_new_loop=False):
         self.awaitable = awaitable
+        try:
+            self.__self__ = self.awaitable.__self__
+        except AttributeError:
+            pass
         if force_new_loop:
             # They have asked that we always run in a new sub-loop.
             self.main_event_loop = None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -262,7 +262,7 @@ def test_async_to_async_method_self_attribute():
     assert number == 45
 
     # Check __self__ has been copied.
-    assert sync_function.__self__ == instance
+    assert sync_function.__self__ is instance
 
 
 def test_thread_sensitive_outside_sync():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -245,6 +245,26 @@ def test_async_to_sync_in_thread():
     assert result["worked"]
 
 
+def test_async_to_async_method_self_attribute():
+    """
+    Tests async_to_async on a method copies __self__.
+    """
+    # Define async function.
+    class TestClass:
+        async def test_function(self):
+            await asyncio.sleep(0)
+            return 45
+
+    # Check it works right.
+    instance = TestClass()
+    sync_function = async_to_sync(instance.test_function)
+    number = sync_function()
+    assert number == 45
+
+    # Check __self__ has been copied.
+    assert sync_function.__self__ == instance
+
+
 def test_thread_sensitive_outside_sync():
     """
     Tests that thread_sensitive SyncToAsync where the outside is sync code runs


### PR DESCRIPTION
This change is required to fix test failure reported in https://github.com/django/django/pull/11650.