### PR TITLE
Remove bdist_wheel from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 testpaths = tests
 


### PR DESCRIPTION
The package is Python 3 only, as such the wheel should not be marked as
"universal" because it does not support Python 2.

https://wheel.readthedocs.io/en/stable/user_guide.html?highlight=universal#building-wheels

> If your project contains no C extensions and is expected to work on
> both Python 2 and 3, …