### PR TITLE
Unpinned test dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - "3.5"
 
 install:
+  - pip install -U pytest  # Travis comes with an old version pre-installed.
   - pip install -e .[tests]
   - pip freeze
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ zip_safe = false
 
 [options.extras_require]
 tests =
-    pytest ~= 4.3.0
-    pytest-asyncio ~= 0.10.0
+    pytest
+    pytest-asyncio
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
AFAICS there's no need to pin the test dependencies. 

Causing hard to track inconsistencies on downstream, e.g. django/daphne#322


Travis ships [with an old Pytest pre-installed](https://travis-ci.org/github/django/asgiref/jobs/696964456#L193-L194), so it's necessary to update it before we begin. 