### PR TITLE
Anchor links in docs are sometimes not "nice"

### DIFF
--- a/specs/www.rst
+++ b/specs/www.rst
@@ -53,8 +53,8 @@ The HTTP protocol should be signified to ASGI applications with a ``type``
 value of ``http``.
 
 
-Connection Scope
-''''''''''''''''
+HTTP Connection Scope
+'''''''''''''''''''''
 
 HTTP connections have a single-request *connection scope* - that is, your
 application will be called at the start of the request, and will last until
@@ -230,8 +230,8 @@ The WebSocket protocol should be signified to ASGI applications with
 a ``type`` value of ``websocket``.
 
 
-Connection Scope
-''''''''''''''''
+Websocket Connection Scope
+''''''''''''''''''''''''''
 
 WebSocket connections' scope lives as long as the socket itself - if the
 application dies the socket should be closed, and vice-versa.

--- a/specs/www.rst
+++ b/specs/www.rst
@@ -364,6 +364,8 @@ Exactly one of ``bytes`` or ``text`` must be non-``None``. One or both
 keys may be present, however.
 
 
+.. _disconnect-receive-event-ws:
+
 Disconnect - ``receive`` event
 ''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
this happens twice in the docs (I didnt see more) and it happens when titles are the same, in that case sphinx generates an anchor link for the 2nd one that looks like this:

https://asgi.readthedocs.io/en/latest/specs/www.html#id1
https://asgi.readthedocs.io/en/latest/specs/www.html#id2

the 1st one is for the Connection scope, it's used twice for http and socket protocol, I dealt with it adding HTTP / Websocket
the 2nd one is for the receive disconnect message,  I dealt with it adding an explicit anchor reference on the 2nd one