### PR TITLE
[RFC] add lifespan.shutdown.notice event

### DIFF
--- a/specs/lifespan.rst
+++ b/specs/lifespan.rst
@@ -88,11 +88,11 @@ Keys:
 
 
 Shutdown Notice - ``receive`` event
-''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''
 
-Sent to the application immediately before the server stops accepting new 
+Sent to the application immediately before the server stops accepting new
 connections and starts shutting down. Useful for signaling long-running or
-looping connections to terminate.
+looping connections, like those using Server-Sent Events, to terminate.
 
 Keys:
 

--- a/specs/lifespan.rst
+++ b/specs/lifespan.rst
@@ -2,7 +2,7 @@
 Lifespan Protocol
 =================
 
-**Version**: 2.0 (2019-03-20)
+**Version**: ?.? (2020-??-??)
 
 The Lifespan ASGI sub-specification outlines how to communicate
 lifespan events such as startup and shutdown within ASGI. This refers to the
@@ -87,6 +87,18 @@ Keys:
 * ``message`` (*Unicode string*) -- Optional; if missing defaults to ``""``.
 
 
+Shutdown Notice - ``receive`` event
+''''''''''''''''''''''''''''''''
+
+Sent to the application immediately before the server stops accepting new 
+connections and starts shutting down. Useful for signaling long-running or
+looping connections to terminate.
+
+Keys:
+
+* ``type`` (*Unicode string*) -- ``"lifespan.shutdown.notice"``.
+
+
 Shutdown - ``receive`` event
 ''''''''''''''''''''''''''''
 
@@ -124,6 +136,8 @@ Keys:
 Version History
 ===============
 
+* ?.? (2020-??-??): Added shutdown.notice for signaling
+  looping applications to exit.
 * 2.0 (2019-03-04): Added startup.failed and shutdown.failed,
   clarified exception handling during startup phase.
 * 1.0 (2018-09-06): Updated ASGI spec with a lifespan protocol.

--- a/specs/lifespan.rst
+++ b/specs/lifespan.rst
@@ -90,9 +90,9 @@ Keys:
 Shutdown Notice - ``receive`` event
 '''''''''''''''''''''''''''''''''''
 
-Sent to the application immediately before the server stops accepting new
-connections and starts shutting down. Useful for signaling long-running or
-looping connections, like those using Server-Sent Events, to terminate.
+Sent to the application immediately after the server stops accepting new
+connections, before it starts shutting down. Useful for signaling long-running
+or looping connections, like those using Server-Sent Events, to terminate.
 
 Keys:
 


### PR DESCRIPTION
Hi 👋  and thanks for the excellent specification! I would like to propose a change to allow looping endpoints to cleanly exit when an ASGI application shuts down.

### Use Case
An ASGI application exposes an indefinitely looping endpoint using [Server-Sent Events](https://www.w3.org/TR/eventsource/) to push unidirectional data to browser clients without client polling or WebSockets.

### Example 
A counter event-stream sends incrementing numbers to a connected client until they disconnect, or the server shuts down.

```python
import asyncio

state = {"should_exit": False, "counter": 0}


async def is_disconnected(receive) -> bool:
    """Check for a "http.disconnect" message"""
    receive_task = asyncio.create_task(receive())
    try:
        await asyncio.wait_for(receive_task, 1)
        message = receive_task.result()
        if message["type"] == "http.disconnect":
            print("disconnect received")
            return True
    except asyncio.TimeoutError:
        receive_task.cancel()
    return False


async def lifespan(scope, receive, send):
    """Handle lifespan events"""
    while True:
        message = await receive()
        if message["type"] == "lifespan.startup":
            print("startup received")
            await send({"type": "lifespan.startup.complete"})
        elif message["type"] == "lifespan.shutdown.notice":
            state["should_exit"] = True
            print("shutdown notice received")
        elif message["type"] == "lifespan.shutdown":
            print("shutdown received")
            await send({"type": "lifespan.shutdown.complete"})
            return


async def http(scope, receive, send):
    message = await receive()
    assert message["type"] == "http.request"

    while message.get("more_body"):
        message = await receive()

    await send(
        {
            "type": "http.response.start",
            "status": 200,
            "headers": [
                (b"cache-control", b"no-cache"),
                (b"content-type", b"text/event-stream"),
                (b"connection", b"keep-alive"),
            ],
        }
    )

    while True:
        await send(
            {
                "type": "http.response.body",
                "body": f"data: {state['counter']}\n\n".encode("utf-8"),
                "more_body": True,
            }
        )
        state["counter"] += 1
        # Check to see if the client disconnected
        if await is_disconnected(receive):
            break
        else:
            print(f"counter = {state['counter']}")

        # The lifespan.shutdown.notice event fired
        if state["should_exit"]:
            print("shutdown notice received, exiting loop")
            await send(
                {
                    "type": "http.response.body",
                    "more_body": False,
                }
            )
            break

        await asyncio.sleep(3)


async def app(scope, receive, send):
    if scope["type"] == "lifespan":
        await lifespan(scope, receive, send)
    elif scope["type"] == "http":
        await http(scope, receive, send)

```


### Problem
With version 2.0 of the lifespan extension, this app can't terminate gracefully without going outside the spec, because the `lifespan.shutdown` event fires "when the server has stopped accepting connections **and closed all active connections**." 

In most cases, firing a shutdown event after all connections have been closed is fine because requests complete and return. However, when you have looping applications that need to break on shutdown, they can't add shutdown handlers to trigger the breakout because they won't fire until the connection has exited.

### Proposal
I explored the minimal changes to support this use-case. Creating a new event looks like the lowest impact way of adding support for signaling connections to gracefully exit. It limits the breakage in existing ASGI frameworks by leaving the "and closed all active connections" requirement for firing `shutdown` while allowing for looping endpoints to exit during application shutdown.