### PR TITLE
Remove deprecated 'sudo: false' from Travis configuraiton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-# Faster container-based infrastructure
-sudo: false
-
 language: python
 
 python:


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration