### PR TITLE
Add support for context-specific thread pool executors.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,9 +163,14 @@ The first compromise you get to might be that ``thread_sensitive`` code should
 just run in the same thread and not spawn in a sub-thread, fulfilling the first
 restriction, but that immediately runs you into the second restriction.
 
-The only real solution is to essentially have a variant of ThreadPoolExecutor
-that executes any ``thread_sensitive`` code on the outermost synchronous
-thread - either the main thread, or a single spawned subthread.
+By default, a variant of ThreadPoolExecutor executes any ``thread_sensitive``
+code on the outermost synchronous thread - either the main thread, or a single
+spawned subthread.
+
+There is an option to override the default single-threaded behavior so that
+there is 1 synchronous thread per context. If ``current_context_func`` is
+specified, this function will be called to retrieve the current context. There
+will be exactly 1 synchronous thread per context in this case.
 
 This means you now have two basic states:
 

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -232,6 +232,12 @@ class SyncToAsync:
     outer code. This is needed for underlying Python code that is not
     threadsafe (for example, code which handles SQLite database connections).
 
+    If current_context_func is passed, the code will run 1 thread per context.
+    As an example, this may be used to create a per-request synchronous thread
+    by specifying the request object as the context. Thread scheduling will
+    occur by request in this scenario - each request will execute synchronous
+    work within the same thread.
+
     If the outermost program is async (i.e. SyncToAsync is outermost), then
     this will be a dedicated single sub-thread that all sync code runs in,
     one after the other. If the outermost program is sync (i.e. AsyncToSync is


### PR DESCRIPTION
As discussed in #223 this PR implements context-specific thread pool capabilities. It does so by creating an input variable (definitely open to updating the name of that input parameter 😛 ) allowing callers of `sync_to_async` to specify a function that returns the current context.

The intended usage of this API is to use [`contextvars` in Django](https://github.com/django/django/compare/master...a-feld:asyncio-perf-improvements) to allow a thread pool per-request.

This PR maintains the existing safety of using a global thread pool per-process by default.