### PR TITLE
Internalize thread sensitive context management in asgiref/sync.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,14 +163,9 @@ The first compromise you get to might be that ``thread_sensitive`` code should
 just run in the same thread and not spawn in a sub-thread, fulfilling the first
 restriction, but that immediately runs you into the second restriction.
 
-By default, a variant of ThreadPoolExecutor executes any ``thread_sensitive``
-code on the outermost synchronous thread - either the main thread, or a single
-spawned subthread.
-
-There is an option to override the default single-threaded behavior so that
-there is 1 synchronous thread per context. If ``current_context_func`` is
-specified, this function will be called to retrieve the current context. There
-will be exactly 1 synchronous thread per context in this case.
+The only real solution is to essentially have a variant of ThreadPoolExecutor
+that executes any ``thread_sensitive`` code on the outermost synchronous
+thread - either the main thread, or a single spawned subthread.
 
 This means you now have two basic states:
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 import pytest
 
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import ThreadSensitiveContext, async_to_sync, sync_to_async
 
 
 @pytest.mark.asyncio
@@ -327,20 +327,17 @@ async def test_thread_sensitive_with_context_different():
     result_1 = {}
     result_2 = {}
 
-    class Context:
-        pass
-
-    context_1 = Context()
-    context_2 = Context()
-
     def store_thread(result):
         result["thread"] = threading.current_thread()
 
-    fn_1 = sync_to_async(store_thread, current_context_func=lambda: context_1)
-    fn_2 = sync_to_async(store_thread, current_context_func=lambda: context_2)
+    store_thread_async = sync_to_async(store_thread)
+
+    async def fn(result):
+        async with ThreadSensitiveContext():
+            await store_thread_async(result)
 
     # Run it (in true parallel!)
-    await asyncio.wait([fn_1(result_1), fn_2(result_2)])
+    await asyncio.wait([fn(result_1), fn(result_2)])
 
     # They should not have run in the main thread, and on different threads
     assert result_1["thread"] != threading.current_thread()
@@ -352,19 +349,19 @@ async def test_thread_sensitive_with_context_matches():
     result_1 = {}
     result_2 = {}
 
-    class Context:
-        pass
-
-    context = Context()
-
     def store_thread(result):
         result["thread"] = threading.current_thread()
 
-    fn_1 = sync_to_async(store_thread, current_context_func=lambda: context)
-    fn_2 = sync_to_async(store_thread, current_context_func=lambda: context)
+    store_thread_async = sync_to_async(store_thread)
 
-    # Run it (in supposed parallel!)
-    await asyncio.wait([fn_1(result_1), fn_2(result_2)])
+    async def fn():
+        async with ThreadSensitiveContext():
+            # Run it (in supposed parallel!)
+            await asyncio.wait(
+                [store_thread_async(result_1), store_thread_async(result_2)]
+            )
+
+    await fn()
 
     # They should not have run in the main thread, and on different threads
     assert result_1["thread"] != threading.current_thread()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,5 +1,6 @@
 import asyncio
 import multiprocessing
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -322,6 +323,10 @@ async def test_thread_sensitive_outside_async():
     assert result_1["thread"] == result_2["thread"]
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 7),
+    reason="contextvars lib is required to use ThreadSensitiveContext",
+)
 @pytest.mark.asyncio
 async def test_thread_sensitive_with_context_different():
     result_1 = {}


### PR DESCRIPTION
Rather than using an external context management function, this commit
updates the thread_sensitive mode to reference an internal contextvar.

This approach mainly allows for the thread executor to be shut down when
the context exits, rather than relying on the thread pool shutting down
when going out of scope.

This approach also has other advantages:
* Maintains the existing sync_to_async interfaces.

* Context variable management cannot be broken by omitting the
  current_context_func arg

* This approach opens the door to more complex management techniques
  such as enforcing a thread pool limit.

Django PR showing implementation: https://github.com/django/django/pull/13882