### PR TITLE
Add a py.typed marker file for PEP 561 compliance

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
+include asgiref/py.typed
 recursive-include tests *.py


### PR DESCRIPTION
This allows the new type hints for the ASGI scopes and messages to be
used. Without this mypy ignores anything from asgiref.