### PR TITLE
fix: move `scope` param from instantiation to call

### DIFF
--- a/asgiref/compatibility.py
+++ b/asgiref/compatibility.py
@@ -30,8 +30,8 @@ def double_to_single_callable(application):
     """
 
     async def new_application(scope, receive, send):
-        instance = application(scope)
-        return await instance(receive, send)
+        instance = application()
+        return await instance(scope, receive, send)
 
     return new_application
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -4,12 +4,12 @@ from asgiref.compatibility import double_to_single_callable, is_double_callable
 from asgiref.testing import ApplicationCommunicator
 
 
-def double_application_function(scope):
+def double_application_function():
     """
     A nested function based double-callable application.
     """
 
-    async def inner(receive, send):
+    async def inner(scope, receive, send):
         message = await receive()
         await send({"scope": scope["value"], "message": message["value"]})
 


### PR DESCRIPTION
Hi,
I'm looking into the following Channels issue https://github.com/django/channels/issues/1588 ([see my comment](https://github.com/django/channels/pull/1621#issuecomment-790264139)] which seems like a bug in asgiref. Considering following:

https://channels.readthedocs.io/en/latest/releases/3.0.0.html#update-to-asgi-3

> Consumers are now ASGI 3 single-callables with the signature:

`application(scope, receive, send)`

> For generic consumers this change should be largely transparent, but you will need to update `__init__()` (no longer taking the scope) and `__call__()` (now taking the scope) if you implemented these yourself.

So it seems `double_application_function` should have the same signature, ie. `scope` should be moved from the point where it's "instantiated" (wrapper) to the point where it's getting "called" (inner function).