### PR TITLE
Fix deprecation warnings for python 3.10

### DIFF
--- a/asgiref/compatibility.py
+++ b/asgiref/compatibility.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import sys
 
 
 def is_double_callable(application):
@@ -45,3 +46,16 @@ def guarantee_single_callable(application):
     if is_double_callable(application):
         application = double_to_single_callable(application)
     return application
+
+
+if sys.version_info >= (3, 7):
+    # these were introduced in 3.7
+    get_running_loop = asyncio.get_running_loop
+    run_future = asyncio.run
+    create_task = asyncio.create_task
+else:
+    # marked as deprecated in 3.10, did not exist before 3.7
+    get_running_loop = asyncio.get_event_loop
+    run_future = asyncio.ensure_future
+    # does nothing, this is fine for <3.7
+    create_task = lambda task: task

--- a/asgiref/server.py
+++ b/asgiref/server.py
@@ -3,7 +3,7 @@ import logging
 import time
 import traceback
 
-from .compatibility import guarantee_single_callable
+from .compatibility import get_running_loop, guarantee_single_callable, run_future
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ class StatelessServer:
         """
         Runs the asyncio event loop with our handler loop.
         """
-        event_loop = asyncio.get_event_loop()
+        event_loop = get_running_loop()
         asyncio.ensure_future(self.application_checker())
         try:
             event_loop.run_until_complete(self.handle())
@@ -88,12 +88,12 @@ class StatelessServer:
         input_queue = asyncio.Queue()
         application_instance = guarantee_single_callable(self.application)
         # Run it, and stash the future for later checking
-        future = asyncio.ensure_future(
+        future = run_future(
             application_instance(
                 scope=scope,
                 receive=input_queue.get,
                 send=lambda message: self.application_send(scope, message),
-            )
+            ),
         )
         self.application_instances[scope_id] = {
             "input_queue": input_queue,

--- a/tests/test_sync_contextvars.py
+++ b/tests/test_sync_contextvars.py
@@ -4,6 +4,7 @@ import time
 
 import pytest
 
+from asgiref.compatibility import create_task
 from asgiref.sync import ThreadSensitiveContext, async_to_sync, sync_to_async
 
 contextvars = pytest.importorskip("contextvars")
@@ -25,7 +26,7 @@ async def test_thread_sensitive_with_context_different():
             await store_thread(result)
 
     # Run it (in true parallel!)
-    await asyncio.wait([fn(result_1), fn(result_2)])
+    await asyncio.wait([create_task(fn(result_1)), create_task(fn(result_2))])
 
     # They should not have run in the main thread, and on different threads
     assert result_1["thread"] != threading.current_thread()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-{test,mypy}
+    py{36,37,38,39,310}-{test,mypy}
     qa
 
 [testenv]


### PR DESCRIPTION
asyncio.get_event_loop was marked as deprecated, the documnetation
now refers to asyncio.get_running_loop([1])

asyncio.ensure_future issues a deprecation warning if there is no
running event loop([2]), so use asyncio.run which creates and destroys the
loop itself

asyncio.gather issues a warning if run outside of event
loop (i.e. there is no running event loop)([3]), so wrap it into an
async def

explicit passing of coroutine objects to asyncio.wait is deprecated
since 3.8([4]), so wrap them in asyncio.create_task

plus, add 3.10 to tox.ini

[1]: https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop
[2]: https://docs.python.org/3.10/library/asyncio-future.html#asyncio.ensure_future
[3]: https://docs.python.org/3.10/library/asyncio-task.html#asyncio.gather
[4]: https://docs.python.org/3.10/library/asyncio-task.html#asyncio.wait