### PR TITLE
Raise on deadlock

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -669,3 +669,26 @@ async def test_sync_to_async_uses_executor():
         thread_sensitive=True,
         executor=custom_executor,
     )
+
+
+def test_sync_to_async_deadlock_raises():
+    def db_write():
+        pass
+
+    async def io_task():
+        await sync_to_async(db_write)()
+
+    async def do_io_tasks():
+        t = asyncio.create_task(io_task())
+        await t
+        # await asyncio.gather(io_task()) # Also deadlocks
+        # await io_task() # Works
+
+    def view():
+        async_to_sync(do_io_tasks)()
+
+    async def server_entry():
+        await sync_to_async(view)()
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(server_entry())

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import multiprocessing
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -671,6 +672,7 @@ async def test_sync_to_async_uses_executor():
     )
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="Issue persists with 3.6")
 def test_sync_to_async_deadlock_raises():
     def db_write():
         pass


### PR DESCRIPTION
Raise an exception on potential deadlock where the single thread pool is awaited on while already being awaited on in the same context 

I'm using a context var here because I think setting an attribute would throw an exception outside of this scenario, if you had multiple 'main' threads just wanting to use the single thread executor, which would not deadlock