### PR TITLE
🐛 Fix extensions type on HTTPScope and WebsocketScope

### DIFF
--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -25,7 +25,7 @@ class HTTPScope(TypedDict):
     headers: Iterable[Tuple[bytes, bytes]]
     client: Optional[Tuple[str, int]]
     server: Optional[Tuple[str, Optional[int]]]
-    extensions: Dict[str, Dict[object, object]]
+    extensions: Optional[Dict[str, Dict[object, object]]]
 
 
 class WebsocketScope(TypedDict):
@@ -41,7 +41,7 @@ class WebsocketScope(TypedDict):
     client: Optional[Tuple[str, int]]
     server: Optional[Tuple[str, Optional[int]]]
     subprotocols: Iterable[str]
-    extensions: Dict[str, Dict[object, object]]
+    extensions: Optional[Dict[str, Dict[object, object]]]
 
 
 class LifespanScope(TypedDict):


### PR DESCRIPTION
@andrewgodwin We are annotating `uvicorn` with `asgiref` now, and possibly extending this idea to `Starlette`. So... Thanks for maintaining it! :)

While I was annotating `uvicorn`, I've noticed that `mypy` complains about the nonexistence of "extensions" so I added it. But after looking at the ASGI specs, it doesn't look like "extensions" is mandatory. Am I wrong?

As per #221 it was decided to use `Optional` to optional fields, instead of making the field optional _per se_, so I've created this PR.