### PR TITLE
New sync_to_async tests, one of which triggers a deadlock

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -728,7 +728,7 @@ async def test_sync_to_async_with_blocker_thread_sensitive():
     Expected to fail at the moment.
     """
 
-    delay = 1 # second
+    delay = 1  # second
     event = multiprocessing.Event()
 
     async def async_process_waiting_on_event():
@@ -763,7 +763,7 @@ async def test_sync_to_async_with_blocker_non_thread_sensitive():
     Tests sync_to_async running on a long-time blocker in a non_thread_sensitive context.
     """
 
-    delay = 1 # second
+    delay = 1  # second
     event = multiprocessing.Event()
 
     async def async_process_waiting_on_event():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -12,6 +12,7 @@ import pytest
 
 from asgiref.compatibility import create_task, get_running_loop
 from asgiref.sync import ThreadSensitiveContext, async_to_sync, sync_to_async
+from asgiref.timeout import timeout
 
 
 @pytest.mark.asyncio
@@ -717,3 +718,75 @@ def test_sync_to_async_deadlock_ignored_with_exception():
             pass
 
     asyncio.run(server_entry())
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail
+async def test_sync_to_async_with_blocker_thread_sensitive():
+    """
+    Tests sync_to_async running on a long-time blocker in a thread_sensitive context.
+    Expected to fail at the moment.
+    """
+
+    delay = 1 # second
+    event = multiprocessing.Event()
+
+    async def async_process_waiting_on_event():
+        """Wait for the event to be set."""
+        await sync_to_async(event.wait)()
+        return 42
+
+    async def async_process_that_triggers_event():
+        """Sleep, then set the event."""
+        await asyncio.sleep(delay)
+        await sync_to_async(event.set)()
+
+    # Run the event setter as a task.
+    trigger_task = asyncio.create_task(async_process_that_triggers_event())
+
+    try:
+        # wait on the event waiter, which is now blocking the event setter.
+        async with timeout(delay + 1):
+            assert await async_process_waiting_on_event() == 42
+    except asyncio.TimeoutError:
+        # In case of timeout, set the event to unblock things, else
+        # downstream tests will get fouled up.
+        event.set()
+        raise
+    finally:
+        await trigger_task
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_with_blocker_non_thread_sensitive():
+    """
+    Tests sync_to_async running on a long-time blocker in a non_thread_sensitive context.
+    """
+
+    delay = 1 # second
+    event = multiprocessing.Event()
+
+    async def async_process_waiting_on_event():
+        """Wait for the event to be set."""
+        await sync_to_async(event.wait, thread_sensitive=False)()
+        return 42
+
+    async def async_process_that_triggers_event():
+        """Sleep, then set the event."""
+        await asyncio.sleep(1)
+        await sync_to_async(event.set)()
+
+    # Run the event setter as a task.
+    trigger_task = asyncio.create_task(async_process_that_triggers_event())
+
+    try:
+        # wait on the event waiter, which is now blocking the event setter.
+        async with timeout(delay + 1):
+            assert await async_process_waiting_on_event() == 42
+    except asyncio.TimeoutError:
+        # In case of timeout, set the event to unblock things, else
+        # downstream tests will get fouled up.
+        event.set()
+        raise
+    finally:
+        await trigger_task

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -742,7 +742,7 @@ async def test_sync_to_async_with_blocker_thread_sensitive():
         await sync_to_async(event.set)()
 
     # Run the event setter as a task.
-    trigger_task = asyncio.create_task(async_process_that_triggers_event())
+    trigger_task = asyncio.ensure_future(async_process_that_triggers_event())
 
     try:
         # wait on the event waiter, which is now blocking the event setter.
@@ -777,7 +777,7 @@ async def test_sync_to_async_with_blocker_non_thread_sensitive():
         await sync_to_async(event.set)()
 
     # Run the event setter as a task.
-    trigger_task = asyncio.create_task(async_process_that_triggers_event())
+    trigger_task = asyncio.ensure_future(async_process_that_triggers_event())
 
     try:
         # wait on the event waiter, which is now blocking the event setter.


### PR DESCRIPTION
These tests provide an example the issues I ran into while moving from asgiref 3.2.10 to 3.3+, which digging through issues here has suggested was not uncommon. Making `sync_to_async` default to `thread_sensitive=True` can cause deadlocks in previously functioning code. I've read and understood why the choice was made, and don't presently have any suggestions on how to better detect and avoid the situation, but figured the distilled scenario in test form might be useful regardless.

---
In these tests, we are waiting on a `mulitprocessing.Event` to be set, with the wait in `sync_to_async()`.

The event is being set in an `asyncio.Task` that sleeps and then calls set, also in `sync_to_async()`. This allows us to kick off the process that would `set()` the event in advance of `wait()`ing for the event, as the event might be triggered by some consumer event.

If both `sync_to_async()` calls are `thread_sensitive=True`, then before `await sync_to_async(event.set)()` can run `event.set()`, `sync_to_async(event.wait)()` has consumed the thread.

asgiref.timeout is used to get us out of the deadlock so the tests can run to completion, and in the case of Timeout we `set()` the event to release the `wait()`.

Finally, we await on the setting task regardless of whether or not there was a timeout.
