### PR TITLE
fix `async_to_async` typo

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -366,9 +366,9 @@ def test_async_to_sync_partial():
     assert result["worked"]
 
 
-def test_async_to_async_method_self_attribute():
+def test_async_to_sync_method_self_attribute():
     """
-    Tests async_to_async on a method copies __self__.
+    Tests async_to_sync on a method copies __self__.
     """
     # Define async function.
     class TestClass:


### PR DESCRIPTION
Something I noticed while working on #282, but which is not part of it.