### PR TITLE
Cache the imported AsyncToSync and SyncToAsync classes on the Local class

### DIFF
--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -31,6 +31,7 @@ class Local:
     """
 
     CLEANUP_INTERVAL = 60  # seconds
+    launch_map_classes = None  # cache imported (AsyncToSync, SyncToAsync) on first access.
 
     def __init__(self, thread_critical: bool = False) -> None:
         self._thread_critical = thread_critical
@@ -48,7 +49,12 @@ class Local:
         Get the ID we should use for looking up variables
         """
         # Prevent a circular reference
-        from .sync import AsyncToSync, SyncToAsync
+        # Once imported the first time, hold a reference to them on the class.
+        if not Local.launch_map_classes:
+            from .sync import AsyncToSync, SyncToAsync
+            Local.launch_map_classes = (AsyncToSync, SyncToAsync)
+        else:
+            AsyncToSync, SyncToAsync = Local.launch_map_classes
 
         # First, pull the current task if we can
         context_id = SyncToAsync.get_current_task()


### PR DESCRIPTION
See issue #269.

On first access, after they're imported the first time, hold a reference to them on the class itself. This nets a small increase in performance by avoiding going through the import machinery on every attribute access of a `Local` instance.

Note that these are bound directly to the `Local` class rather than testing the instance (self) attributes, as doing so in the simple way would yield a RecursionError due to `__getattr__` depending on `_get_context_id`

Using the same example as I provided in the issue:
```
In [1]: from asgiref.local import Local
   ...: x = Local()
   ...: def timeonly():
   ...:     setattr(x, 'test', None)
   ...:     for _ in range(100_000):
   ...:         getattr(x, 'test')
In [2]: %timeit timeonly()
329 ms ± 5.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [3]: %prun timeonly()
...
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   100001    0.139    0.000    0.313    0.000 local.py:47(_get_context_id)
   100000    0.080    0.000    0.502    0.000 local.py:107(__getattr__)
200001/100001    0.076    0.000    0.568    0.000 {built-in method builtins.getattr}
   100001    0.073    0.000    0.407    0.000 local.py:88(_get_storage)
   100001    0.067    0.000    0.123    0.000 sync.py:493(get_current_task)
   100001    0.029    0.000    0.044    0.000 tasks.py:34(current_task)
   100001    0.026    0.000    0.038    0.000 threading.py:1318(current_thread)
   200002    0.023    0.000    0.023    0.000 {built-in method builtins.hasattr}
...
```
vs prior to the patch:
```
In [2]: %timeit timeonly()
448 ms ± 8.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [3]: %prun timeonly()
...
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   100001    0.255    0.000    0.490    0.000 local.py:46(_get_context_id)
   100000    0.085    0.000    0.685    0.000 local.py:101(__getattr__)
200001/100001    0.076    0.000    0.750    0.000 {built-in method builtins.getattr}
   100001    0.072    0.000    0.584    0.000 local.py:82(_get_storage)
   100001    0.070    0.000    0.133    0.000 sync.py:493(get_current_task)
   100001    0.036    0.000    0.050    0.000 <frozen importlib._bootstrap>:398(parent)
   100001    0.030    0.000    0.046    0.000 tasks.py:34(current_task)
   200002    0.029    0.000    0.029    0.000 {built-in method builtins.hasattr}
   100001    0.027    0.000    0.040    0.000 threading.py:1318(current_thread)
...
```

This may still not be what Andrew was specifically hoping for, but given touching `self.x` in the simple/naive way is problematic (see above), I'm opting for this as the simplest possible solution from which discussion for improvement can follow.