### PR TITLE
Hoist deciding which asyncio current_task to use to module definition time.

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -15,8 +15,11 @@ from .local import Local
 
 if sys.version_info >= (3, 7):
     import contextvars
+
+    current_task = asyncio.current_task
 else:
     contextvars = None
+    current_task = asyncio.Task.current_task
 
 
 def _restore_context(context):
@@ -498,12 +501,7 @@ class SyncToAsync:
         Returns None if there is no task.
         """
         try:
-            if hasattr(asyncio, "current_task"):
-                # Python 3.7 and up
-                return asyncio.current_task()
-            else:
-                # Python 3.6
-                return asyncio.Task.current_task()
+            return current_task()
         except RuntimeError:
             return None
 


### PR DESCRIPTION
Unless I'm missing runtime/implementation specific details, I can't see a reason the decision about whether to use `asyncio.current_task` or `asyncio.Task.current_task` cannot be decided once at import time.

My naive, underestimating guess is that when it was done in 51d5c4618a34a16cb6a14624e0e4d35dc92978ae and 768a0718269c309bf2a5a3c4c9558d55c56283d5 it was without the memory of there being an import-time branch covering the same Python versions in e3e1cc84612065b0b61c03e96fdfb8a7854a5f85.

This saves 1 `hasattr` call every time `mylocal.myvar` or `getattr(mylocal, 'myvar')` are used; timings are on a laptop so are y'know, fluxxy.

Before:
```
In [1]: from asgiref.local import Local
   ...: x = Local()
   ...: def timeonly():
   ...:     setattr(x, 'test', None)
   ...:     for _ in range(100_000):
   ...:         getattr(x, 'test')
In [2]: %timeit timeonly()
441 ms ± 17.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [3]: %timeit timeonly()
429 ms ± 11.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [4]: %timeit timeonly()
430 ms ± 7.88 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [5]: %prun timeonly()
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
...
   100001    0.068    0.000    0.126    0.000 sync.py:493(get_current_task)
   100001    0.035    0.000    0.049    0.000 <frozen importlib._bootstrap>:398(parent)
   100001    0.030    0.000    0.045    0.000 tasks.py:34(current_task)
   100001    0.027    0.000    0.039    0.000 threading.py:1318(current_thread)
   200002    0.023    0.000    0.023    0.000 {built-in method builtins.hasattr}
...
```

After:
```
In [2]: %timeit timeonly()
415 ms ± 4.27 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [3]: %timeit timeonly()
420 ms ± 5.06 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [4]: %timeit timeonly()
418 ms ± 7.61 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [5]: %prun timeonly()
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
...
   100001    0.054    0.000    0.099    0.000 sync.py:496(get_current_task)   <--- a bit less time, over time.
   100001    0.037    0.000    0.051    0.000 <frozen importlib._bootstrap>:398(parent)
   100001    0.030    0.000    0.045    0.000 tasks.py:34(current_task)
   100001    0.027    0.000    0.039    0.000 threading.py:1318(current_thread)
...
   100001    0.013    0.000    0.013    0.000 {built-in method builtins.hasattr}   <--- amortized cost.
...
```

Edit: adding line_profile output (`%lprun -f Local._get_context_id timeonly()`), before:
```
Function: _get_context_id at line 46
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    46                                               def _get_context_id(self):
...
    54    100001     219071.0      2.2     21.4          context_id = SyncToAsync.get_current_task()
```
after:
```
Function: _get_context_id at line 46
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    46                                               def _get_context_id(self):
...
    54    100001     186731.0      1.9     18.5          context_id = SyncToAsync.get_current_task()
```