### PR TITLE
timeout module: Hoist deciding which asyncio current_task to use to module definition time

### DIFF
--- a/asgiref/compatibility.py
+++ b/asgiref/compatibility.py
@@ -53,9 +53,11 @@ if sys.version_info >= (3, 7):
     get_running_loop = asyncio.get_running_loop
     run_future = asyncio.run
     create_task = asyncio.create_task
+    current_task = asyncio.current_task
 else:
     # marked as deprecated in 3.10, did not exist before 3.7
     get_running_loop = asyncio.get_event_loop
     run_future = asyncio.ensure_future
     # does nothing, this is fine for <3.7
     create_task = lambda task: task
+    current_task = asyncio.Task.current_task

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -9,17 +9,14 @@ import weakref
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable, Dict, Optional, overload
 
-from .compatibility import get_running_loop
+from .compatibility import current_task, get_running_loop
 from .current_thread_executor import CurrentThreadExecutor
 from .local import Local
 
 if sys.version_info >= (3, 7):
     import contextvars
-
-    current_task = asyncio.current_task
 else:
     contextvars = None
-    current_task = asyncio.Task.current_task
 
 
 def _restore_context(context):

--- a/asgiref/timeout.py
+++ b/asgiref/timeout.py
@@ -7,9 +7,10 @@
 
 
 import asyncio
-import sys
 from types import TracebackType
 from typing import Any, Optional, Type
+
+from .compatibility import current_task as asyncio_current_task
 
 
 class timeout:
@@ -114,10 +115,7 @@ class timeout:
 
 
 def current_task(loop: asyncio.AbstractEventLoop) -> "Optional[asyncio.Task[Any]]":
-    if sys.version_info >= (3, 7):
-        task = asyncio.current_task(loop=loop)
-    else:
-        task = asyncio.Task.current_task(loop=loop)
+    task = asyncio_current_task(loop=loop)
     if task is None:
         # this should be removed, tokio must use register_task and family API
         fn = getattr(loop, "current_task", None)


### PR DESCRIPTION
Follows up on f53fbef (#289). Note that the module level variable used here differs, because it is already in use as the public function name.

As with that one, saves 1 `hasattr` call per usage, this time of of `asgiref.timeout.current_task`