### PR TITLE
Removed Local.CLEANUP_INTERVAL class variable which has been unused for a while

### DIFF
--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -30,8 +30,6 @@ class Local:
     3.7 only, we can then reimplement the storage more nicely.
     """
 
-    CLEANUP_INTERVAL = 60  # seconds
-
     def __init__(self, thread_critical: bool = False) -> None:
         self._thread_critical = thread_critical
         self._thread_lock = threading.RLock()


### PR DESCRIPTION
It was last used prior to a0bbe901ffe19cd927219989b7125a920ea1e5c3 and tags < `3.2.6`
It may be going through an informal deprecation cycle, or it may've just been missed (wood for the trees etc). Either way, when it's appropriate, this should be OK to merge. One hopes.