### PR TITLE
Typing for sync/async decorators

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ zip_safe = false
 tests =
     pytest
     pytest-asyncio
-    mypy>=0.800
+    mypy @ git+https://github.com/python/mypy.git@master
 
 [tool:pytest]
 testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ zip_safe = false
 tests =
     pytest
     pytest-asyncio
-    mypy @ git+https://github.com/python/mypy.git@master
+    mypy>=0.920
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
This is a first pass draft, fairly sure it's broken for python versions lower than 3.8. 

Seems to work but i'm not sure how to test it right this moment, i'm used to using pyright and will have to investigate how to use mypy

One thing that confused me a bit is that the async_to_sync function accepts `awaitable` but it actually seems to be looking for a callable that returns an awaitable? I could use some clarification there.

I'm also not sure what naming convention to use for the TypeVar/Paramspec pairs.

Looks like I also introduce some formatting errors to correct!