### PR TITLE
Added stacklevel to warning in AsyncToSync.

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -122,7 +122,9 @@ class AsyncToSync:
         if not callable(awaitable) or not _iscoroutinefunction_or_partial(awaitable):
             # Python does not have very reliable detection of async functions
             # (lots of false negatives) so this is just a warning.
-            warnings.warn("async_to_sync was passed a non-async-marked callable")
+            warnings.warn(
+                "async_to_sync was passed a non-async-marked callable", stacklevel=2
+            )
         self.awaitable = awaitable
         try:
             self.__self__ = self.awaitable.__self__


### PR DESCRIPTION
Outputs the line from the calling code when printing the warning, which makes it
easier to track down the problem without re-running with `-Werror`.