### PR TITLE
Added testing for Python 3.10.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
         - 3.7
         - 3.8
         - 3.9
+        - '3.10'
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Internet :: WWW/HTTP
 project_urls =
     Documentation = https://asgi.readthedocs.io/

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ tests =
 
 [tool:pytest]
 testpaths = tests
+asyncio_mode = strict
 
 [flake8]
 exclude = venv/*,tox/*,specs/*

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -94,7 +94,7 @@ async def server_auto_close(fut, timeout):
     """Server run based on run_until_complete. It will block forever with handle
     function because it is a while True loop without break.  Use this method to close
     server automatically."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     task = asyncio.ensure_future(fut, loop=loop)
     await asyncio.sleep(timeout)
     task.cancel()
@@ -105,7 +105,8 @@ def test_stateless_server(server):
     """Create a UDP Server can register instance based on name from message of client.
     Clients can communicate to other client by name through server"""
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     server.handle = partial(server_auto_close, fut=server.handle(), timeout=1.0)
 
     client1 = Client(name="client1")
@@ -132,7 +133,8 @@ def test_stateless_server(server):
 
 def test_server_delete_instance(server):
     """The max_applications of Server is 10. After 20 times register, application number should be 10."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     server.handle = partial(server_auto_close, fut=server.handle(), timeout=1.0)
 
     client1 = Client(name="client1")


### PR DESCRIPTION
This also fixes deprecation warnings in `tests/test_server.py`:
```
tests/test_server.py::test_stateless_server
  /asgiref/tests/test_server.py:108: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop()
tests/test_server.py::test_server_delete_instance
  /asgiref/tests/test_server.py:135: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop()
```