### PR TITLE
Fix allowed values for `spec_version` on WebSocket and HTTP Connection scopes

### DIFF
--- a/specs/www.rst
+++ b/specs/www.rst
@@ -73,8 +73,8 @@ The *connection scope* information passed in ``scope`` contains:
 * ``asgi["version"]`` (*Unicode string*) -- Version of the ASGI spec.
 
 * ``asgi["spec_version"]`` (*Unicode string*) -- Version of the ASGI
-  HTTP spec this server understands; one of ``"2.0"`` or
-  ``"2.1"``. Optional; if missing assume ``2.0``.
+  HTTP spec this server understands; one of ``"2.0"``, ``"2.1"``, ``"2.2"`` or
+  ``"2.3"``. Optional; if missing assume ``2.0``.
 
 * ``http_version`` (*Unicode string*) -- One of ``"1.0"``, ``"1.1"`` or ``"2"``.
 
@@ -253,8 +253,8 @@ metadata (mostly from the HTTP request line and headers):
 * ``asgi["version"]`` (*Unicode string*) -- The version of the ASGI spec.
 
 * ``asgi["spec_version"]`` (*Unicode string*) -- Version of the ASGI
-  HTTP spec this server understands; one of ``"2.0"`` or
-  ``"2.1"``. Optional; if missing assume ``"2.0"``.
+  HTTP spec this server understands; one of ``"2.0"``, ``"2.1"``, ``"2.2"`` or
+  ``"2.3"``. Optional; if missing assume ``"2.0"``.
 
 * ``http_version`` (*Unicode string*) -- One of ``"1.1"`` or
   ``"2"``. Optional; if missing default is ``"1.1"``.


### PR DESCRIPTION
Those values were not up-to-date considering what is on the top of the page:

![image](https://user-images.githubusercontent.com/7353520/150789561-634f5b0e-e220-4a04-a05e-612c23a1f49c.png)