### PR TITLE
make sure that test_multiprocessing uses the fork method

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -625,7 +625,8 @@ async def test_multiprocessing():
 
     def fork_first():
         """Forks process before running sync_process"""
-        fork = multiprocessing.Process(target=sync_process)
+        ctx = multiprocessing.get_context("fork")
+        fork = ctx.Process(target=sync_process)
         fork.start()
         fork.join(3)
         # Force cleanup in failed test case


### PR DESCRIPTION
I think this is the most direct way to fix #313: simply enforce the use of the fork method.

Using the spawn method leads to tests failing because it's not possible
to pickle local functions. plus, the tests was added to test the
interaction with fork, so it does not make sense with spawn anyway.