### PR TITLE
rewrite the test to use no local functions

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -607,32 +607,33 @@ def test_sync_to_async_detected_as_coroutinefunction():
     assert asyncio.iscoroutinefunction(sync_to_async(sync_func))
 
 
+async def async_process(queue):
+    queue.put(42)
+
+
+def sync_process(queue):
+    """Runs async_process synchronously"""
+    async_to_sync(async_process)(queue)
+
+
+def fork_first():
+    """Forks process before running sync_process"""
+    queue = multiprocessing.Queue()
+    fork = multiprocessing.Process(target=sync_process, args=[queue])
+    fork.start()
+    fork.join(3)
+    # Force cleanup in failed test case
+    if fork.is_alive():
+        fork.terminate()
+    return queue.get(True, 1)
+
+
 @pytest.mark.asyncio
 async def test_multiprocessing():
     """
     Tests that a forked process can use async_to_sync without it looking for
     the event loop from the parent process.
     """
-
-    test_queue = multiprocessing.Queue()
-
-    async def async_process():
-        test_queue.put(42)
-
-    def sync_process():
-        """Runs async_process synchronously"""
-        async_to_sync(async_process)()
-
-    def fork_first():
-        """Forks process before running sync_process"""
-        fork = multiprocessing.Process(target=sync_process)
-        fork.start()
-        fork.join(3)
-        # Force cleanup in failed test case
-        if fork.is_alive():
-            fork.terminate()
-        return test_queue.get(True, 1)
-
     assert await sync_to_async(fork_first)() == 42
 
 


### PR DESCRIPTION
Option 2 to fix #313: make things pickle-friendly by rewriting the test to not use local functions.