### PR TITLE
Remove `SOCK_NONBLOCK` from socket creation on tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: ["--py37-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--target-version=py37"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ zip_safe = false
 
 [options.extras_require]
 tests =
-    click==8.0.4
     pytest
     pytest-asyncio
     mypy>=0.800

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ zip_safe = false
 
 [options.extras_require]
 tests =
+    click==8.0.4
     pytest
     pytest-asyncio
     mypy>=0.800

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,7 +21,8 @@ class Server(StatelessServer):
             application,
             max_applications=max_applications,
         )
-        self._sock = sock.socket(sock.AF_INET, sock.SOCK_DGRAM | sock.SOCK_NONBLOCK)
+        self._sock = sock.socket(sock.AF_INET, sock.SOCK_DGRAM)
+        self._sock.setblocking(False)
         self._sock.bind(("127.0.0.1", 0))
 
     @property
@@ -54,7 +55,8 @@ class Server(StatelessServer):
 
 class Client:
     def __init__(self, name):
-        self._sock = sock.socket(sock.AF_INET, sock.SOCK_DGRAM | sock.SOCK_NONBLOCK)
+        self._sock = sock.socket(sock.AF_INET, sock.SOCK_DGRAM)
+        self._sock.setblocking(False)
         self.name = name
 
     async def register(self, server_addr, name=None):


### PR DESCRIPTION
This fixes running tests on Mac OS X, which lacks the `SOCK_NONBLOCK`
socket flag creation.