### PR TITLE
Don't warn 'non-async-marked callable' for async callable instance

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -107,7 +107,12 @@ class AsyncToSync:
     loop_thread_executors: "Dict[asyncio.AbstractEventLoop, CurrentThreadExecutor]" = {}
 
     def __init__(self, awaitable, force_new_loop=False):
-        if not callable(awaitable) or not _iscoroutinefunction_or_partial(awaitable):
+        if not callable(awaitable) or (
+            not _iscoroutinefunction_or_partial(awaitable)
+            and not _iscoroutinefunction_or_partial(
+                getattr(awaitable, "__call__", awaitable)
+            )
+        ):
             # Python does not have very reliable detection of async functions
             # (lots of false negatives) so this is just a warning.
             warnings.warn(

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3,6 +3,7 @@ import functools
 import multiprocessing
 import threading
 import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from unittest import TestCase
@@ -378,14 +379,14 @@ def test_async_to_sync_on_callable_object():
             result["worked"] = True
             return value
 
-    # Run it
-    with pytest.warns(None) as recorded_warnings:
+    # Run it (without warnings)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         sync_function = async_to_sync(CallableClass())
         out = sync_function(42)
 
     assert out == 42
     assert result["worked"] is True
-    assert len(recorded_warnings) == 0
 
 
 def test_async_to_sync_method_self_attribute():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -365,6 +365,29 @@ def test_async_to_sync_partial():
     assert result["worked"]
 
 
+def test_async_to_sync_on_callable_object():
+    """
+    Tests async_to_sync on a callable class instance
+    """
+
+    result = {}
+
+    class CallableClass:
+        async def __call__(self, value):
+            await asyncio.sleep(0)
+            result["worked"] = True
+            return value
+
+    # Run it
+    with pytest.warns(None) as recorded_warnings:
+        sync_function = async_to_sync(CallableClass())
+        out = sync_function(42)
+
+    assert out == 42
+    assert result["worked"] is True
+    assert len(recorded_warnings) == 0
+
+
 def test_async_to_sync_method_self_attribute():
     """
     Tests async_to_sync on a method copies __self__.


### PR DESCRIPTION
Fixes #324 