### PR TITLE
Noted Daphne as original, rather than current, reference server.

### DIFF
--- a/docs/implementations.rst
+++ b/docs/implementations.rst
@@ -13,7 +13,7 @@ Daphne
 
 *Stable* / http://github.com/django/daphne
 
-The current ASGI reference server, written in Twisted and maintained as part
+The original ASGI reference server, written in Twisted and maintained as part
 of the Django Channels project. Supports HTTP/1, HTTP/2, and WebSockets.
 
 


### PR DESCRIPTION
As per https://github.com/django/daphne/issues/264 — Daphne lacks Lifespan support, and shouldn't now be labelled the _reference_ implementation. 

Just a wording tweak to that effect.