### PR TITLE
Disallow async callable class instances as callable for `sync.SyncToAsync`

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -356,7 +356,11 @@ class SyncToAsync:
         thread_sensitive: bool = True,
         executor: Optional["ThreadPoolExecutor"] = None,
     ) -> None:
-        if not callable(func) or _iscoroutinefunction_or_partial(func):
+        if (
+            not callable(func)
+            or _iscoroutinefunction_or_partial(func)
+            or _iscoroutinefunction_or_partial(getattr(func, "__call__", func))
+        ):
             raise TypeError("sync_to_async can only be applied to sync functions.")
         self.func = func
         functools.update_wrapper(self, func)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -100,6 +100,18 @@ async def test_async_to_sync_fail_partial():
 
 
 @pytest.mark.asyncio
+async def test_sync_to_async_raises_typeerror_for_async_callable_instance():
+    class CallableClass:
+        async def __call__(self):
+            return None
+
+    with pytest.raises(
+        TypeError, match="sync_to_async can only be applied to sync functions."
+    ):
+        sync_to_async(CallableClass())
+
+
+@pytest.mark.asyncio
 async def test_sync_to_async_decorator():
     """
     Tests sync_to_async as a decorator


### PR DESCRIPTION
i.e. passing an instance defining `async def __call__(...)` to `sync.SyncToAsync` will raise a `TypeError`

Refs: #324 
Fixes: #327 