### PR TITLE
Use update_wrapper in SyncToAsync.__get__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 .python-version
 .pytest_cache/
 .vscode/
+.venv

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -445,7 +445,8 @@ class SyncToAsync:
         """
         Include self for methods
         """
-        return functools.partial(self.__call__, parent)
+        func = functools.partial(self.__call__, parent)
+        return functools.update_wrapper(func, self.func)
 
     def thread_handler(self, loop, source_task, exc_info, func, *args, **kwargs):
         """


### PR DESCRIPTION
Adds an `update_wrapper` in `SyncToAsync.__get__` to get more context out of the returned partial.
Same behavior as in `AsyncToSync`