### PR TITLE
Removed support for ASGI_THREADS environment variable.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,13 @@
+UNRELEASED
+----------
+
+* Support for the ``ASGI_THREADS`` environment variable, used by
+  ``SyncToAsync``, is removed. In general, a running event-loop is not
+  available to `asgiref` at import time, and so the default thread pool
+  executor cannot be configured. Protocol servers, or applications, should set
+  the default executor as required when configuring the event loop at
+  application startup.
+
 3.5.2 (2022-05-16)
 ------------------
 

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -314,15 +314,6 @@ class SyncToAsync:
     a TypeError will be raised.
     """
 
-    # If they've set ASGI_THREADS, update the default asyncio executor for now
-    if "ASGI_THREADS" in os.environ:
-        # We use get_event_loop here - not get_running_loop - as this will
-        # be run at import time, and we want to update the main thread's loop.
-        loop = asyncio.get_event_loop()
-        loop.set_default_executor(
-            ThreadPoolExecutor(max_workers=int(os.environ["ASGI_THREADS"]))
-        )
-
     # Maps launched threads to the coroutines that spawned them
     launch_map: "Dict[threading.Thread, asyncio.Task[object]]" = {}
 


### PR DESCRIPTION
This is a request-for-comment on the support for setting the `ASGI_THREADS` environment variable in `SyncToAsync`.

* For Daphne it doesn't work, since the we don't use the event loop returned by `get_event_loop()`. See https://github.com/django/daphne/issues/319
* `get_event_loop()` is deprecated, and will become an alias for `get_running_loop()` in a future Python version. This code will at that point raise a `RuntimeError` since there won't be a running event loop. 
* Even the _happy path_ assumes `asgiref.sync` is imported on the main thread, since it's only then that a new loop is automatically created. 

For the Daphne issue, we'll add the similar code there to configure the executor on the loop in use, but it seems it needs removing from, or fixing in, asgiref too. (I can't see an appropriate home for it; is it's even really asgiref's concern? 🤔)

//cc @apollo13.  
