### PR TITLE
Updated timeout helper to use get_running_loop().

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
 UNRELEASED
 ----------
 
+* The ``loop`` argument to ``asgiref.timeout.timeout`` is deprecated. As per other
+  ``asyncio`` based APIs, the running event loop is used by default. Note that
+  ``asyncio`` provides timeout utilities from Python 3.11, and these should be
+  preferred where available.
+
 * Support for the ``ASGI_THREADS`` environment variable, used by
   ``SyncToAsync``, is removed. In general, a running event-loop is not
   available to `asgiref` at import time, and so the default thread pool

--- a/asgiref/timeout.py
+++ b/asgiref/timeout.py
@@ -35,7 +35,7 @@ class timeout:
     ) -> None:
         self._timeout = timeout
         if loop is None:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
         self._loop = loop
         self._task = None  # type: Optional[asyncio.Task[Any]]
         self._cancelled = False

--- a/asgiref/timeout.py
+++ b/asgiref/timeout.py
@@ -7,6 +7,7 @@
 
 
 import asyncio
+import warnings
 from types import TracebackType
 from typing import Any  # noqa
 from typing import Optional, Type
@@ -36,6 +37,10 @@ class timeout:
         self._timeout = timeout
         if loop is None:
             loop = asyncio.get_running_loop()
+        else:
+            warnings.warn(
+                """The loop argument to timeout() is deprecated.""", DeprecationWarning
+            )
         self._loop = loop
         self._task = None  # type: Optional[asyncio.Task[Any]]
         self._cancelled = False


### PR DESCRIPTION
> The `get_running_loop()` function is preferred to `get_event_loop()` in coroutines and callbacks.