### PR TITLE
Add HTTP Trailers extension

### DIFF
--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -16,6 +16,7 @@ __all__ = (
     "HTTPRequestEvent",
     "HTTPResponseStartEvent",
     "HTTPResponseBodyEvent",
+    "HTTPResponseTrailersEvent",
     "HTTPServerPushEvent",
     "HTTPDisconnectEvent",
     "WebSocketConnectEvent",
@@ -99,12 +100,19 @@ class HTTPResponseStartEvent(TypedDict):
     type: Literal["http.response.start"]
     status: int
     headers: Iterable[Tuple[bytes, bytes]]
+    trailers: bool
 
 
 class HTTPResponseBodyEvent(TypedDict):
     type: Literal["http.response.body"]
     body: bytes
     more_body: bool
+
+
+class HTTPResponseTrailersEvent(TypedDict):
+    type: Literal["http.response.trailers"]
+    headers: Iterable[Tuple[bytes, bytes]]
+    more_trailers: bool
 
 
 class HTTPServerPushEvent(TypedDict):

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -152,10 +152,14 @@ ASGI servers that implement this extension will provide
         },
     }
 
-An ASGI framework interested in sending trailing headers to the client, must include
-the ``Trailer`` header in the ``http.response.start``. That will allow the ASGI server
+An ASGI framework interested in sending trailing headers to the client, must set the
+field ``trailers`` in *Response Start* as ``True``. That will allow the ASGI server
 to know that after the last ``http.response.body`` message (``more_body`` being ``False``),
 the ASGI framework will send a ``http.response.trailers`` message.
+
+The ASGI framework is in charge of sending the ``Trailers`` headers to let the client know
+which trailing headers the server will send. The ASGI server is not responsible for validating
+the ``Trailers`` headers provided.
 
 Keys:
 
@@ -165,6 +169,13 @@ Keys:
   ``[name, value]`` two-item iterables, where ``name`` is the header name, and
   ``value`` is the header value. Header names must be lowercased. Pseudo
   headers (present in HTTP/2 and HTTP/3) must not be present.
+
+* ``more_trailers`` (*bool*): Signifies if there is additional content
+  to come (as part of a *HTTP Trailers* message). If ``False``, response
+  will be taken as complete and closed, and any further messages on
+  the channel will be ignored. Optional; if missing defaults to
+  ``False``.
+
 
 The ASGI server will only send the trailing headers in case the client has sent the
 ``TE: trailers`` header in the request.

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -133,3 +133,38 @@ TLS
 ---
 
 See :doc:`specs/tls`.
+
+HTTP Trailers
+---
+
+The Trailer response header allows the sender to include additional fields at the
+end of chunked messages in order to supply metadata that might be dynamically
+generated while the message body is sent, such as a message integrity check,
+digital signature, or post-processing status.
+
+ASGI servers that implement this extension will provide
+``http.response.trailers`` in the extensions part of the scope::
+
+    "scope": {
+        ...
+        "extensions": {
+            "http.response.trailers": {},
+        },
+    }
+
+An ASGI framework interested in sending trailing headers to the client, must include
+the ``Trailer`` header in the ``http.response.start``. That will allow the ASGI server
+to know that after the last ``http.response.body`` message (``more_body`` being ``False``),
+the ASGI framework will send a ``http.response.trailers`` message.
+
+Keys:
+
+* ``type`` (*Unicode string*): ``"http.response.trailers"``
+
+* ``headers`` (*Iterable[[byte string, byte string]]*): An iterable of
+  ``[name, value]`` two-item iterables, where ``name`` is the header name, and
+  ``value`` is the header value. Header names must be lowercased. Pseudo
+  headers (present in HTTP/2 and HTTP/3) must not be present.
+
+The ASGI server will only send the trailing headers in case the client has sent the
+``TE: trailers`` header in the request.

--- a/specs/www.rst
+++ b/specs/www.rst
@@ -185,14 +185,19 @@ Keys:
   lowercased. Optional; if missing defaults to an empty list. Pseudo
   headers (present in HTTP/2 and HTTP/3) must not be present.
 
+* ``trailers`` (*bool*) -- Signifies if the application will send
+  trailers. If ``True``, the server must wait until it receives a
+  ``"http.response.trailers"`` message after the *Response Body* event.
+  Optional; if missing defaults to ``False``.
+
 
 Response Body - ``send`` event
 ''''''''''''''''''''''''''''''
 
 Continues sending a response to the client. Protocol servers must
 flush any data passed to them into the send buffer before returning from a
-send call. If ``more_body`` is set to ``False`` this will
-close the connection.
+send call. If ``more_body`` is set to ``False``, and the server is not
+expecting *Response Trailers* this will close the connection.
 
 Keys:
 
@@ -203,10 +208,10 @@ Keys:
   missing defaults to ``b""``.
 
 * ``more_body`` (*bool*) -- Signifies if there is additional content
-  to come (as part of a Response Body message). If ``False``, response
-  will be taken as complete and closed, and any further messages on
-  the channel will be ignored. Optional; if missing defaults to
-  ``False``.
+  to come (as part of a *Response Body* message). If ``False``, and the
+  server is not expecting *Response Trailers* response will be taken as
+  complete and closed, and any further messages on the channel will be
+  ignored. Optional; if missing defaults to ``False``.
 
 
 Disconnect - ``receive`` event


### PR DESCRIPTION
- Closes #141

Currently, there are two implementations of HTTP Trailer:
- https://github.com/encode/uvicorn/pull/1599/ (Uvicorn)
- https://github.com/nonebot/nonecorn/blob/nonecorn_dev/src/hypercorn/protocol/http_stream.py#L232 (Nonecorn - Hypercorn fork) - Commit that introduced it: https://github.com/nonebot/nonecorn/commit/222757f8da25fc5b716b790b93c23710942790b4

What this PR proposes doesn't match any of those two implementations. I've tried to simplify a bit...

The uvicorn one introduces a new key on the `http.response.start` called `trailers`, to show the intention from the application to the server that trailing headers will be sent. I think this is not needed. The server can understand the intention if the header `Trailer:` is provided on the `headers` from the `http.response.start`.

The nonecorn uses a different name for the extension, but it was the first one implemented. I just thought the name `http.response.trailers` was a bit better, but happy to change if wanted. cc @synodriver

~I understood less about the nonecorn implementation in comparison to the one from uvicorn, so I may be missing something here that I couldn't grasp from there. So I'd like your opinion here @synodriver. 🙏~

The `nonecorn` implementation makes the ASGI framework in charge of sending the `Trailer:` header, and it sets the `more_body` field to `True` on the last `http.response.body` message, and then it's able to use trailing headers message (called `http.trailingheaders.send` there) as last message, and then close the transport after it.  

cc @simonw @abersheeran @pgjones @synodriver @sam-kleiner @tomchristie 

References used to write this:
- https://fullstack.wiki/http/headers/Trailer
- https://fullstack.wiki/http/headers/TE
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer
- https://chromium.googlesource.com/external/github.com/grpc/grpc/+/HEAD/doc/PROTOCOL-HTTP2.md