### PR TITLE
RE: Add HTTP Trailers 

### DIFF
--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -16,6 +16,7 @@ __all__ = (
     "HTTPRequestEvent",
     "HTTPResponseStartEvent",
     "HTTPResponseBodyEvent",
+    "HTTPResponseTrailersEvent",
     "HTTPServerPushEvent",
     "HTTPDisconnectEvent",
     "WebSocketConnectEvent",
@@ -99,12 +100,18 @@ class HTTPResponseStartEvent(TypedDict):
     type: Literal["http.response.start"]
     status: int
     headers: Iterable[Tuple[bytes, bytes]]
+    trailers: bool
 
 
 class HTTPResponseBodyEvent(TypedDict):
     type: Literal["http.response.body"]
     body: bytes
     more_body: bool
+
+
+class HTTPResponseTrailersEvent(TypedDict):
+    type: Literal["http.response.trailers"]
+    trailers: Iterable[Tuple[bytes, bytes]]
 
 
 class HTTPServerPushEvent(TypedDict):
@@ -202,6 +209,7 @@ ASGIReceiveEvent = Union[
 ASGISendEvent = Union[
     HTTPResponseStartEvent,
     HTTPResponseBodyEvent,
+    HTTPResponseTrailersEvent,
     HTTPServerPushEvent,
     HTTPDisconnectEvent,
     WebSocketAcceptEvent,
@@ -224,9 +232,7 @@ class ASGI2Protocol(Protocol):
     def __init__(self, scope: Scope) -> None:
         ...
 
-    async def __call__(
-        self, receive: ASGIReceiveCallable, send: ASGISendCallable
-    ) -> None:
+    async def __call__(self, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
         ...
 
 

--- a/specs/www.rst
+++ b/specs/www.rst
@@ -185,6 +185,9 @@ Keys:
   lowercased. Optional; if missing defaults to an empty list. Pseudo
   headers (present in HTTP/2 and HTTP/3) must not be present.
 
+* ``trailers`` (*bool*) -- Signifies if there are trailers
+  to come after the body. Optional; if missing defaults to
+  ``False``.
 
 Response Body - ``send`` event
 ''''''''''''''''''''''''''''''
@@ -192,7 +195,7 @@ Response Body - ``send`` event
 Continues sending a response to the client. Protocol servers must
 flush any data passed to them into the send buffer before returning from a
 send call. If ``more_body`` is set to ``False`` this will
-close the connection.
+close the connection, unless trailers are expected.
 
 Keys:
 
@@ -205,8 +208,27 @@ Keys:
 * ``more_body`` (*bool*) -- Signifies if there is additional content
   to come (as part of a Response Body message). If ``False``, response
   will be taken as complete and closed, and any further messages on
-  the channel will be ignored. Optional; if missing defaults to
-  ``False``.
+  the channel will be ignored. One trailers message may be sent after
+  the final body message if ``trailers`` was set to ``True`` in the start
+  message. Optional; if missing defaults to ``False``.
+
+
+Response Trailers - ``send`` event
+''''''''''''''''''''''''''''''
+
+Sent by the application after the body. Can only be sent if ``trailers``
+was set to ``True`` in the start message. The connection will be
+closed after this message.
+
+Keys:
+
+* ``type`` (*Unicode string*) -- ``"http.response.trailers"``.
+
+* ``trailers`` (*Iterable[[byte string, byte string]]*) -- An iterable
+  of ``[name, value]`` two-item iterables, where ``name`` is the
+  trailer name, and ``value`` is the trailer value. Order must be
+  preserved in the HTTP response.  Trailer names must be
+  lowercased. Optional; if missing defaults to an empty list.
 
 
 Disconnect - ``receive`` event


### PR DESCRIPTION
There is already a [PR](https://github.com/django/asgiref/pull/339) open regarding this. I wanted to open this to add options to the discussion. I did the [uvicorn implementation](https://github.com/encode/uvicorn/pull/1599).

As stated in the other proposal PR this works a bit differently. This adds a new message type `http.response.trailers` and a new `trailers` bool property to `http.response.start`. IMO this simplifies the implementation. 

My original POC did not account for chunked trailers but this would be easy to add with a `more_trailers` property similar to the `more_body` property.

Personally I like the `more_body` being set to false when the body is done and trailers being sent after. It makes more sense to me, but at the end of the day if any trailers get added I will be happy.