### PR TITLE
Simplified contextvars usage.

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -395,9 +395,7 @@ class SyncToAsync:
             if hasattr(AsyncToSync.executors, "current"):
                 # If we have a parent sync thread above somewhere, use that
                 executor = AsyncToSync.executors.current
-            elif self.thread_sensitive_context and self.thread_sensitive_context.get(
-                None
-            ):
+            elif self.thread_sensitive_context.get(None):
                 # If we have a way of retrieving the current context, attempt
                 # to use a per-context thread pool executor
                 thread_sensitive_context = self.thread_sensitive_context.get()
@@ -412,15 +410,14 @@ class SyncToAsync:
             elif loop in AsyncToSync.loop_thread_executors:
                 # Re-use thread executor for running loop
                 executor = AsyncToSync.loop_thread_executors[loop]
-            elif self.deadlock_context and self.deadlock_context.get(False):
+            elif self.deadlock_context.get(False):
                 raise RuntimeError(
                     "Single thread executor already being used, would deadlock"
                 )
             else:
                 # Otherwise, we run it in a fixed single thread
                 executor = self.single_thread_executor
-                if self.deadlock_context:
-                    self.deadlock_context.set(True)
+                self.deadlock_context.set(True)
         else:
             # Use the passed in executor, or the loop's default if it is None
             executor = self._executor
@@ -449,8 +446,7 @@ class SyncToAsync:
 
         finally:
             _restore_context(context)
-            if self.deadlock_context:
-                self.deadlock_context.set(False)
+            self.deadlock_context.set(False)
 
         return ret
 

--- a/tests/test_sync_contextvars.py
+++ b/tests/test_sync_contextvars.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import threading
 import time
 
@@ -6,9 +7,7 @@ import pytest
 
 from asgiref.sync import ThreadSensitiveContext, async_to_sync, sync_to_async
 
-contextvars = pytest.importorskip("contextvars")
-
-foo = contextvars.ContextVar("foo")
+foo: "contextvars.ContextVar[str]" = contextvars.ContextVar("foo")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Contextvars are unconditionally available since dropping Python 3.6 support in 02fecb6046bb5ec0dbbad00ffcd2043e893fcea5.