### PR TITLE
Update isort version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: ["--target-version=py37"]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.2
+    rev: 5.11.5
     hooks:
       - id: isort
         args: ["--profile=black"]


### PR DESCRIPTION
Update isort to 5.11.5 due to https://github.com/PyCQA/isort/issues/2083
isort 5.12.0 is out too, but It appears to have already dropped support for python 3.7.
