### PR TITLE
Add ParamSpec typing for AsyncToSync and SyncToAsync

### DIFF
--- a/asgiref/current_thread_executor.py
+++ b/asgiref/current_thread_executor.py
@@ -1,6 +1,9 @@
 import queue
 import threading
 from concurrent.futures import Executor, Future
+from typing import Any, TypeVar
+
+T = TypeVar("T")
 
 
 class _WorkItem:
@@ -35,12 +38,14 @@ class CurrentThreadExecutor(Executor):
     the thread they came from.
     """
 
-    def __init__(self):
+    _work_queue: "queue.Queue[Any]"
+
+    def __init__(self) -> None:
         self._work_thread = threading.current_thread()
         self._work_queue = queue.Queue()
         self._broken = False
 
-    def run_until_future(self, future):
+    def run_until_future(self, future: "Future[T]") -> None:
         """
         Runs the code in the work queue until a result is available from the future.
         Should be run from the thread the executor is initialised in.

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -26,8 +26,10 @@ from typing import (
     overload,
 )
 
-# Use typing_extensions until python 3.9 support is dropped
-from typing_extensions import ParamSpec
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 from .current_thread_executor import CurrentThreadExecutor
 from .local import Local

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ zip_safe = false
 tests =
     pytest
     pytest-asyncio
-    mypy>=0.800
+    mypy>=0.991
     pytest-mypy-plugins
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ python_requires = >=3.7
 packages = find:
 include_package_data = true
 install_requires =
-    typing_extensions; python_version < "3.8"
+    typing_extensions; python_version < "3.10"
 zip_safe = false
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ tests =
     pytest
     pytest-asyncio
     mypy>=0.800
+    pytest-mypy-plugins
 
 [tool:pytest]
 testpaths = tests

--- a/tests/test_sync_types.yml
+++ b/tests/test_sync_types.yml
@@ -1,0 +1,21 @@
+# Test asgiref.sync types, especially the complex generics
+- case: return_type_of_sync_to_async_matches_caller
+  main: |
+    from asgiref.sync import sync_to_async
+    def func(name: str, repeat: int) -> str:
+        return "hello {name} " * repeat
+    
+    async def main():
+        async_func = sync_to_async(func)
+        res = await async_func("mypy", 2)
+        reveal_type(res)  # N: Revealed type is "str"
+- case: return_type_of_async_to_sync_matches_caller
+  main: |
+    from asgiref.sync import async_to_sync
+    async def async_func(name: str, repeat: int) -> str:
+        return "hello {name} " * repeat
+    
+    def main():
+        func = sync_to_async(async_func)
+        res = func("mypy", 2)
+        reveal_type(res)  # N: Revealed type is "str"

--- a/tests/test_typing.yml
+++ b/tests/test_typing.yml
@@ -1,0 +1,26 @@
+# Test types in asgiref.typing module
+- case: asgi3_application_callable_wrong_parameters
+  main: |
+    from asgiref.typing import ASGI3Application, Scope, ASGIReceiveCallable, ASGISendCallable
+
+    async def asgi3_application(scope: Scope, send: ASGISendCallable, receive: ASGIReceiveCallable) -> None:
+        return None
+
+    my_app: ASGI3Application = asgi3_application  # ER: Incompatible types in assignment.*
+- case: asgi3_application_as_class
+  main: |
+    from asgiref.typing import ASGI3Application, Scope, ASGIReceiveCallable, ASGISendCallable
+    from typing import Optional
+
+    class MyMiddlewareApplication:
+        def __init__(self, inner_app: Optional[ASGI3Application] = None):
+            self.__inner = inner_app
+    
+        async def __call__(self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+            if self.__inner:
+                return await self.__inner(scope, receive, send)
+            else:
+                raise RuntimeError("Byyeee")
+
+    my_app: ASGI3Application = MyMiddlewareApplication()
+  # No result expected (should type-check okay)


### PR DESCRIPTION
This uses typing-extensions to add ParamSpec typing to the decorators and their related classes sync_to_async and async_to_sync.

The typing-extensions dependency needed to be extended to python 3.9, to provide backported support for ParamSpec.

Also found through some manual testing that the minimum mypy version that works with ParamSpec is 0.991. Maybe this means this PR needs to wait for at least an asgiref minor release, as it will affect the version of mypy people need to be using.
