### PR TITLE
Clarify ambigious section of lifespan["state"] spec

### DIFF
--- a/specs/lifespan.rst
+++ b/specs/lifespan.rst
@@ -59,12 +59,6 @@ lifespan protocol. If you want to log an error that occurs during lifespan
 startup and prevent the server from starting, then send back
 ``lifespan.startup.failed`` instead.
 
-The ``extensions["lifespan.state"]`` dict is an empty namespace.
-Applications can store arbitrary data in this namespace.
-A *shallow copy* of this dictionary will get passed into each request handler.
-This key will only be set if the server supports this extension.
-
-
 Lifespan State
 --------------
 

--- a/specs/www.rst
+++ b/specs/www.rst
@@ -312,6 +312,10 @@ metadata (mostly from the HTTP request line and headers):
 * ``subprotocols`` (*Iterable[Unicode string]*) -- Subprotocols the
   client advertised. Optional; if missing defaults to empty list.
 
+* ``state`` Optional(*dict[Unicode string, Any]*) -- A copy of the
+  namespace passed into the lifespan corresponding to this request. (See :doc:`lifespan`).
+  Optional; if missing the server does not support this feature.
+
 
 Connect - ``receive`` event
 '''''''''''''''''''''''''''


### PR DESCRIPTION
Addressing https://github.com/django/asgiref/pull/354#discussion_r1125446663 and https://github.com/django/asgiref/pull/354#discussion_r1125446411