### PR TITLE
Fix typo in lifespan state spec

### DIFF
--- a/specs/lifespan.rst
+++ b/specs/lifespan.rst
@@ -65,7 +65,7 @@ Lifespan State
 Applications often want to persist data from the lifespan cycle to request/response handling.
 For example, a database connection can be established in the lifespan cycle and persisted to
 the request/response cycle.
-The ``lifespan["state"]`` namespace provides a place to store these sorts of things.
+The ``scope["state"]`` namespace provides a place to store these sorts of things.
 The server will ensure that a *shallow copy* of the namespace is passed into each subsequent
 request/response call into the application.
 Since the server manages the application lifespan and often the event loop as well this


### PR DESCRIPTION
Hi there,

This is a fix for the "Lifespan state" spec docs: https://asgi.readthedocs.io/en/latest/specs/lifespan.html#lifespan-state

The prose mentions `lifespan["state"]` but the example code shows `scope["state"]`. My understanding is that the latter is the correct reference.

cc @Kludex 