### PR TITLE
Remove extra call to `asyncio.wait_for`

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -430,7 +430,7 @@ class SyncToAsync:
 
         try:
             # Run the code in the right thread
-            future = loop.run_in_executor(
+            ret = await loop.run_in_executor(
                 executor,
                 functools.partial(
                     self.thread_handler,
@@ -442,7 +442,6 @@ class SyncToAsync:
                     **kwargs,
                 ),
             )
-            ret = await asyncio.wait_for(future, timeout=None)
 
         finally:
             _restore_context(context)


### PR DESCRIPTION
This is a very simple patch. I noticed it in stack traces when I was working on https://github.com/django/django/pull/16636, and thought it was odd.

I took a closer look today and confirmed my hypothesis: this does nothing.

The definition for `asyncio.wait_for` when `timeout=None` just `await`s the future and returns the value:

https://github.com/python/cpython/blob/3.7/Lib/asyncio/tasks.py#L413-L414

This logic was added in Python 3.4 (predating even `async`/`await` syntax): https://github.com/python/cpython/commit/48c66c3dd82e0f345350f99d0c8713cc1e686939

(the logic was eventually modernized in https://github.com/python/cpython/commit/5f841b553814969220b096a2b4f959b7f6fcbaf6#diff-429f4ed1e0f89ea2c92e2a8e8548ea8ae1a3d528979554fbfa4c38329e951529R333)

The original provenence for this `asyncio.wait_for` call within `asgiref` dates back to https://github.com/django/asgiref/commit/b51e2598ae470b6a4bf93bc8255365e2e5a9246a (by way of several refactors)

I don't know enough about this system to comment on what the intent was, but perhaps that within the larger refactor this small detail was missed? I'm not sure *shrug*.

CC @andrewgodwin as maybe you recall what the intent was in the original commit?

In any event, my interest in this change is that  it removes one more "asgiref internal" stack frame from tracebacks / error messages.
