### PR TITLE
Use `__traceback_hide__` to skip frames in tracebacks

### DIFF
--- a/asgiref/current_thread_executor.py
+++ b/asgiref/current_thread_executor.py
@@ -16,6 +16,7 @@ class _WorkItem:
         self.kwargs = kwargs
 
     def run(self):
+        __traceback_hide__ = True  # noqa: F841
         if not self.future.set_running_or_notify_cancel():
             return
         try:

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -167,6 +167,8 @@ class AsyncToSync:
                     self.main_event_loop = None
 
     def __call__(self, *args, **kwargs):
+        __traceback_hide__ = True  # noqa: F841
+
         # You can't call AsyncToSync from a thread with a running event loop
         try:
             event_loop = asyncio.get_running_loop()
@@ -289,6 +291,9 @@ class AsyncToSync:
         Wraps the awaitable with something that puts the result into the
         result/exception future.
         """
+
+        __traceback_hide__ = True  # noqa: F841
+
         if context is not None:
             _restore_context(context[0])
 
@@ -388,6 +393,7 @@ class SyncToAsync:
             pass
 
     async def __call__(self, *args, **kwargs):
+        __traceback_hide__ = True  # noqa: F841
         loop = asyncio.get_running_loop()
 
         # Work out what thread to run the code in
@@ -461,6 +467,9 @@ class SyncToAsync:
         """
         Wraps the sync application with exception handling.
         """
+
+        __traceback_hide__ = True  # noqa: F841
+
         # Set the threadlocal for AsyncToSync
         self.threadlocal.main_event_loop = loop
         self.threadlocal.main_event_loop_pid = os.getpid()


### PR DESCRIPTION
This idea came from ongoing work in https://github.com/django/django/pull/16636 to try and hide sensitive variables in an `async` wrapper for a synchronous function in the `auth` contrib app in Django.

Basically, Django supports skipping frames that have a truthy `__traceback_hide__` value in the frame's locals:

https://github.com/django/django/blob/85b52d22fd2841c34e95b3a80d6f2b668ce2f160/django/views/debug.py#L523-L527

We could take advantage of this pre-existing logic in Django and hide the internals of the `asgiref.sync` machinery.

Adopting this idea has 2 advantages:
1. Users don't need to see frames they don't care about, this leans more in to the "just call `async_to_sync`/`sync_to_async` functions and don't worry about the rough edges" concept discussed in the README
2. Hide potentially sensitive variables from tracebacks / error logs.

To elaborate on (2), https://github.com/django/django/pull/16668 was an attempt to hide sensitive variables from `async` functions and failed, and lots of the discussion in https://github.com/django/django/pull/16636 has been around trying to hide the sensitive variables within asgiref's internal machinery.

Disadvantages that I see:
1. This is lying to the user. Right now frames internal to Django are shown on tracebacks, but are less eye-catching (see screenshots below) which is a compelling argument against this.
2. Due to some calls from `asgiref` to built-in Python code there are a few frame we can't hide, which leads to a disjointed experience (see second set of screenshots).
3. This is basically only useful in Django (and maybe some testing frameworks?) and otherwise is just noise

The big idea is that from an user's perspective they call `async_to_sync` or `sync_to_async` and *magic happens* and they get the result they want.

Another thought is that we could make this system opt-in:

```py
# asgiref/__init__.py

hide_internals_in_tracebacks = False

# asgiref/sync.py
from asgiref import hide_internals_in_tracebacks

...
def internal_func():
  __traceback_hide__ = hide_internals_in_tracebacks
...

# <user code>.py

import asgiref

asgiref.hide_internals_in_tracebacks = True

from asgiref.sync import sync_to_async

async def foo():
  return await sync_to_async(sync_function)()

```

Then perhaps Django would opt-in by default, but I'm just designing this on the fly. I'm not committed to this idea but saw an opportunity.

I've prepared some screenshots showing this in-action to get an idea how this would feel for users:

(note, these screenshots were prepared on top of https://github.com/django/asgiref/pull/382, so add one more frame if that PR is not accepted)

| Type | Current | Proposed |
| ------- | ----------- | -------------- |
| `sync_to_async` | ![current_sync_to_async](https://user-images.githubusercontent.com/6403568/229010734-e2c01769-13b1-4244-9952-d429111b13c5.png) | ![after_sync_to_async](https://user-images.githubusercontent.com/6403568/229010762-8c66dbc9-2741-465c-84cd-88beb65c3a0f.png) |
| `async_to_sync` | ![current_async_to_sync](https://user-images.githubusercontent.com/6403568/229010777-24920be5-2a27-4f14-9f65-64c30abad99b.png) | ![after_async_to_sync](https://user-images.githubusercontent.com/6403568/229010791-b71ce44d-8d6b-4f25-b44a-7184cbfd202b.png) |
