### PR TITLE
Allow Local instances to be cleared without deleting

### DIFF
--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -84,7 +84,7 @@ class Local:
             self._context_refs.add(context_obj)
         return getattr(context_obj, self._attr_name)
 
-    def __del__(self):
+    def clear(self):
         try:
             for context_obj in self._context_refs:
                 try:
@@ -95,6 +95,9 @@ class Local:
             # WeakSet.__iter__ can crash when interpreter is shutting down due
             # to _IterationGuard being None.
             pass
+
+    def __del__(self):
+        self.clear()
 
     def __getattr__(self, key):
         with self._thread_lock:


### PR DESCRIPTION
Greetings, lovely people! 

I'm in the process of using `Local` in a couple of projects, and recently had a case where I wanted to clear   cached values based on certain signals, without deleting the object completely. 

I'm sure you'll agree the changes are super simple, but I feel this tiny change brings the API more in-line with other familiar cache options, and I think may help with adoption.

Thank you for all the wonderful work so far, folks.