### PR TITLE
Better garbage-collection on exceptions in sync_to_async

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -481,6 +481,9 @@ class SyncToAsync:
         else:
             self.launch_map[current_thread] = source_task
             parent_set = True
+        source_task = (
+            None  # allow the task to be garbage-collected in case of exceptions
+        )
         # Run the function
         try:
             # If we have an exception, run the function inside the except block


### PR DESCRIPTION
This fixes a garbage-collection issue explained in: https://stackoverflow.com/q/76118191/326792

Current implementation of `sync_to_async` blocks python from garbage-collecting failed tasks with reference-counting. The explicit assignment of local variable `source_task` to `None` fixes this!
