### PR TITLE
Improve sync.py typing and utilities performance

### DIFF
--- a/asgiref/current_thread_executor.py
+++ b/asgiref/current_thread_executor.py
@@ -1,7 +1,13 @@
 import queue
+import sys
 import threading
 from concurrent.futures import Executor, Future
-from typing import Any, Callable, ParamSpec, TypeVar, Union
+from typing import Any, Callable, TypeVar, Union
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")

--- a/asgiref/current_thread_executor.py
+++ b/asgiref/current_thread_executor.py
@@ -1,6 +1,11 @@
 import queue
 import threading
 from concurrent.futures import Executor, Future
+from typing import Any, Callable, ParamSpec, TypeVar, Union
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 class _WorkItem:
@@ -9,13 +14,19 @@ class _WorkItem:
     Copied from ThreadPoolExecutor (but it's private, so we're not going to rely on importing it)
     """
 
-    def __init__(self, future, fn, args, kwargs):
+    def __init__(
+        self,
+        future: Future[_R],
+        fn: Callable[_P, _R],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ):
         self.future = future
         self.fn = fn
         self.args = args
         self.kwargs = kwargs
 
-    def run(self):
+    def run(self) -> None:
         __traceback_hide__ = True  # noqa: F841
         if not self.future.set_running_or_notify_cancel():
             return
@@ -24,7 +35,7 @@ class _WorkItem:
         except BaseException as exc:
             self.future.set_exception(exc)
             # Break a reference cycle with the exception 'exc'
-            self = None
+            self = None  # type: ignore[assignment]
         else:
             self.future.set_result(result)
 
@@ -36,12 +47,12 @@ class CurrentThreadExecutor(Executor):
     the thread they came from.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._work_thread = threading.current_thread()
-        self._work_queue = queue.Queue()
+        self._work_queue: queue.Queue[Union[_WorkItem, Future[Any]]] = queue.Queue()
         self._broken = False
 
-    def run_until_future(self, future):
+    def run_until_future(self, future: Future[Any]) -> None:
         """
         Runs the code in the work queue until a result is available from the future.
         Should be run from the thread the executor is initialised in.
@@ -60,12 +71,19 @@ class CurrentThreadExecutor(Executor):
                 work_item = self._work_queue.get()
                 if work_item is future:
                     return
+                assert isinstance(work_item, _WorkItem)
                 work_item.run()
                 del work_item
         finally:
             self._broken = True
 
-    def submit(self, fn, *args, **kwargs):
+    def submit(
+        self,
+        fn: Callable[_P, _R],
+        /,
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Future[_R]:
         # Check they're not submitting from the same thread
         if threading.current_thread() == self._work_thread:
             raise RuntimeError(
@@ -75,8 +93,8 @@ class CurrentThreadExecutor(Executor):
         if self._broken:
             raise RuntimeError("CurrentThreadExecutor already quit or is broken")
         # Add to work queue
-        f = Future()
-        work_item = _WorkItem(f, fn, args, kwargs)
+        f: Future[_R] = Future()
+        work_item = _WorkItem(f, fn, *args, **kwargs)
         self._work_queue.put(work_item)
         # Return the future
         return f

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -17,6 +17,7 @@ from typing import (
     Coroutine,
     Dict,
     Generic,
+    List,
     Optional,
     TypeVar,
     Union,
@@ -215,7 +216,7 @@ class AsyncToSync(Generic[_P, _R]):
         context = [contextvars.copy_context()]
 
         # Make a future for the return information
-        call_result: Future[_R] = Future()
+        call_result: "Future[_R]" = Future()
         # Get the source thread
         source_thread = threading.current_thread()
         # Make a CurrentThreadExecutor we'll use to idle in this thread - we
@@ -320,10 +321,10 @@ class AsyncToSync(Generic[_P, _R]):
 
     async def main_wrap(
         self,
-        call_result: Future[_R],
+        call_result: "Future[_R]",
         source_thread: threading.Thread,
         exc_info: "OptExcInfo",
-        context: list[contextvars.Context],
+        context: List[contextvars.Context],
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> None:
@@ -542,7 +543,7 @@ class SyncToAsync(Generic[_P, _R]):
                 del self.launch_map[current_thread]
 
     @staticmethod
-    def get_current_task() -> Optional[asyncio.Task[Any]]:
+    def get_current_task() -> Optional["asyncio.Task[Any]"]:
         """
         Implementation of asyncio.current_task()
         that returns None if there is no task.
@@ -569,7 +570,6 @@ def sync_to_async(
 @overload
 def sync_to_async(
     func: Callable[_P, _R],
-    /,
     *,
     thread_sensitive: bool = True,
     executor: Optional["ThreadPoolExecutor"] = None,

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -9,21 +9,42 @@ import threading
 import warnings
 import weakref
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, Callable, Dict, Optional, overload
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Dict,
+    Generic,
+    Optional,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from .current_thread_executor import CurrentThreadExecutor
 from .local import Local
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 def _restore_context(context):
     # Check for changes in contextvars, and set them to the current
     # context for downstream consumers
     for cvar in context:
+        cvalue = context.get(cvar)
         try:
-            if cvar.get() != context.get(cvar):
-                cvar.set(context.get(cvar))
+            if cvar.get() != cvalue:
+                cvar.set(cvalue)
         except LookupError:
-            cvar.set(context.get(cvar))
+            cvar.set(cvalue)
 
 
 # Python 3.12 deprecates asyncio.iscoroutinefunction() as an alias for
@@ -32,29 +53,25 @@ def _restore_context(context):
 # Until 3.12 is the minimum supported Python version, provide a shim.
 # Django 4.0 only supports 3.8+, so don't concern with the _or_partial backport.
 
-# Type hint: should be generic: whatever T it takes it returns. (Same id)
-def markcoroutinefunction(func: Any) -> Any:
-    if hasattr(inspect, "markcoroutinefunction"):
-        return inspect.markcoroutinefunction(func)
-    else:
+if hasattr(inspect, "markcoroutinefunction"):
+    iscoroutinefunction = inspect.iscoroutinefunction
+    markcoroutinefunction: Callable[[_F], _F] = inspect.markcoroutinefunction
+else:
+    iscoroutinefunction = asyncio.iscoroutinefunction  # type: ignore[assignment]
+
+    def markcoroutinefunction(func: _F) -> _F:
         func._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore
         return func
 
 
-def iscoroutinefunction(func: Any) -> bool:
-    if hasattr(inspect, "markcoroutinefunction"):
-        return inspect.iscoroutinefunction(func)
-    else:
-        return asyncio.iscoroutinefunction(func)
+if sys.version_info >= (3, 8):
+    _iscoroutinefunction_or_partial = iscoroutinefunction
+else:
 
-
-def _iscoroutinefunction_or_partial(func: Any) -> bool:
-    # Python < 3.8 does not correctly determine partially wrapped
-    # coroutine functions are coroutine functions, hence the need for
-    # this to exist. Code taken from CPython.
-    if sys.version_info >= (3, 8):
-        return iscoroutinefunction(func)
-    else:
+    def _iscoroutinefunction_or_partial(func: Any) -> bool:
+        # Python < 3.8 does not correctly determine partially wrapped
+        # coroutine functions are coroutine functions, hence the need for
+        # this to exist. Code taken from CPython.
         while inspect.ismethod(func):
             func = func.__func__
         while isinstance(func, functools.partial):
@@ -104,7 +121,7 @@ class ThreadSensitiveContext:
         SyncToAsync.thread_sensitive_context.reset(self.token)
 
 
-class AsyncToSync:
+class AsyncToSync(Generic[_P, _R]):
     """
     Utility class which turns an awaitable that only works on the thread with
     the event loop into a synchronous callable that works in a subthread.
@@ -128,7 +145,14 @@ class AsyncToSync:
     # inside create_task, we'll look it up here from the running event loop.
     loop_thread_executors: "Dict[asyncio.AbstractEventLoop, CurrentThreadExecutor]" = {}
 
-    def __init__(self, awaitable, force_new_loop=False):
+    def __init__(
+        self,
+        awaitable: Union[
+            Callable[_P, Coroutine[Any, Any, _R]],
+            Callable[_P, Awaitable[_R]],
+        ],
+        force_new_loop: bool = False,
+    ):
         if not callable(awaitable) or (
             not _iscoroutinefunction_or_partial(awaitable)
             and not _iscoroutinefunction_or_partial(
@@ -142,7 +166,7 @@ class AsyncToSync:
             )
         self.awaitable = awaitable
         try:
-            self.__self__ = self.awaitable.__self__
+            self.__self__ = self.awaitable.__self__  # type: ignore[union-attr]
         except AttributeError:
             pass
         if force_new_loop:
@@ -166,7 +190,7 @@ class AsyncToSync:
                 else:
                     self.main_event_loop = None
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         __traceback_hide__ = True  # noqa: F841
 
         # You can't call AsyncToSync from a thread with a running event loop
@@ -186,7 +210,7 @@ class AsyncToSync:
         context = [contextvars.copy_context()]
 
         # Make a future for the return information
-        call_result = Future()
+        call_result: Future[_R] = Future()
         # Get the source thread
         source_thread = threading.current_thread()
         # Make a CurrentThreadExecutor we'll use to idle in this thread - we
@@ -277,7 +301,7 @@ class AsyncToSync:
                 loop.close()
                 asyncio.set_event_loop(self.main_event_loop)
 
-    def __get__(self, parent, objtype):
+    def __get__(self, parent: Any, objtype: Any) -> Callable[_P, _R]:
         """
         Include self for methods
         """
@@ -298,6 +322,7 @@ class AsyncToSync:
             _restore_context(context[0])
 
         current_task = SyncToAsync.get_current_task()
+        assert current_task is not None
         self.launch_map[current_task] = source_thread
         try:
             # If we have an exception, run the function inside the except block
@@ -319,7 +344,7 @@ class AsyncToSync:
             context[0] = contextvars.copy_context()
 
 
-class SyncToAsync:
+class SyncToAsync(Generic[_P, _R]):
     """
     Utility class which turns a synchronous callable into an awaitable that
     runs in a threadpool. It also sets a threadlocal inside the thread so
@@ -352,8 +377,8 @@ class SyncToAsync:
 
     # Maintain a contextvar for the current execution context. Optionally used
     # for thread sensitive mode.
-    thread_sensitive_context: "contextvars.ContextVar[str]" = contextvars.ContextVar(
-        "thread_sensitive_context"
+    thread_sensitive_context: "contextvars.ContextVar[ThreadSensitiveContext]" = (
+        contextvars.ContextVar("thread_sensitive_context")
     )
 
     # Contextvar that is used to detect if the single thread executor
@@ -364,13 +389,13 @@ class SyncToAsync:
 
     # Maintaining a weak reference to the context ensures that thread pools are
     # erased once the context goes out of scope. This terminates the thread pool.
-    context_to_thread_executor: "weakref.WeakKeyDictionary[object, ThreadPoolExecutor]" = (
+    context_to_thread_executor: "weakref.WeakKeyDictionary[ThreadSensitiveContext, ThreadPoolExecutor]" = (
         weakref.WeakKeyDictionary()
     )
 
     def __init__(
         self,
-        func: Callable[..., Any],
+        func: Callable[_P, _R],
         thread_sensitive: bool = True,
         executor: Optional["ThreadPoolExecutor"] = None,
     ) -> None:
@@ -392,7 +417,7 @@ class SyncToAsync:
         except AttributeError:
             pass
 
-    async def __call__(self, *args, **kwargs):
+    async def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         __traceback_hide__ = True  # noqa: F841
         loop = asyncio.get_running_loop()
 
@@ -431,12 +456,10 @@ class SyncToAsync:
         context = contextvars.copy_context()
         child = functools.partial(self.func, *args, **kwargs)
         func = context.run
-        args = (child,)
-        kwargs = {}
 
         try:
             # Run the code in the right thread
-            ret = await loop.run_in_executor(
+            ret: _R = await loop.run_in_executor(
                 executor,
                 functools.partial(
                     self.thread_handler,
@@ -444,8 +467,7 @@ class SyncToAsync:
                     self.get_current_task(),
                     sys.exc_info(),
                     func,
-                    *args,
-                    **kwargs,
+                    child,
                 ),
             )
 
@@ -455,7 +477,9 @@ class SyncToAsync:
 
         return ret
 
-    def __get__(self, parent, objtype):
+    def __get__(
+        self, parent: Any, objtype: Any
+    ) -> Callable[_P, Coroutine[Any, Any, _R]]:
         """
         Include self for methods
         """
@@ -519,27 +543,29 @@ async_to_sync = AsyncToSync
 
 @overload
 def sync_to_async(
-    func: None = None,
+    *,
     thread_sensitive: bool = True,
     executor: Optional["ThreadPoolExecutor"] = None,
-) -> Callable[[Callable[..., Any]], SyncToAsync]:
+) -> Callable[[Callable[_P, _R]], SyncToAsync[_P, _R]]:
     ...
 
 
 @overload
 def sync_to_async(
-    func: Callable[..., Any],
+    func: Callable[_P, _R],
+    /,
+    *,
     thread_sensitive: bool = True,
     executor: Optional["ThreadPoolExecutor"] = None,
-) -> SyncToAsync:
+) -> SyncToAsync[_P, _R]:
     ...
 
 
 def sync_to_async(
-    func=None,
-    thread_sensitive=True,
-    executor=None,
-):
+    func: Optional[Callable[_P, _R]] = None,
+    thread_sensitive: bool = True,
+    executor: Optional["ThreadPoolExecutor"] = None,
+) -> Union[Callable[[Callable[_P, _R]], SyncToAsync[_P, _R]], SyncToAsync[_P, _R]]:
     if func is None:
         return lambda f: SyncToAsync(
             f,


### PR DESCRIPTION
* Make sure `sync_to_async`/`async_to_sync` keeps the original function typing signature

* Define iscoroutinefunction/markcoroutinefunction at import time instead of an if/else in runtime.

The current implementation:
```python
In [7]: timeit.timeit(lambda: iscoroutinefunction(some_sync_func), number=10000)
Out[7]: 0.012024379917420447
```

Versus this PR
```python
In [11]: timeit.timeit(lambda: iscoroutinefunction(some_sync_func), number=10000)
Out[11]: 0.004663120023906231
```

This is a performance improvement of almost 300%.