### PR TITLE
Updated release steps in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ Then, build and push the packages::
 
     python -m build
     twine upload dist/*
-    rm -r build/ dist/
+    rm -r asgiref.egg-info dist
 
 
 Implementation Details


### PR DESCRIPTION
The `build` module doesn't create the `build` folder in the local directory. It's probably also worth cleaning up the .egg-info in the last step.