### PR TITLE
Reset doc theme to ReadTheDocs' default theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,10 @@ build:
   tools:
     python: "3.12"
 
+python:
+  install:
+    - requirements: docs/requirements.txt
+
 sphinx:
   configuration: docs/conf.py
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "default"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
On [2023](https://blog.readthedocs.com/defaulting-latest-build-tools/), RTD made changes to the tools that are automatically installed. I'm pretty sure (though that might a false memory) that the Asgi doc used to use the rtd theme. Fact is that it now uses the default theme which looks [_so retro it belongs in a museum_](https://fosstodon.org/@carlton/112140615717929142).

This PR resets the theme to RTD.
What this PR exactly does:
- Add a docs/requirements.txt file with docs dependencies
- Change the value for the theme

What this PR doesn't do but could (you tell me):
- Pin dependencies in docs/requirements.txt (I don't see dependabot or renovate being used in the repo so I'm wary of adding pinned deps, as they'll likely get old quick)
- Use a more modern theme such as Pradyun's excellent [furo](https://github.com/pradyunsg/furo)

I haven't changed the RTD build, and I see that this repo isn't configured to build docs in PRs. It should be as simple as checking this checkbox in the [RTD admin](https://readthedocs.org/dashboard/asgi/edit/), as long as github permissions are set correctly:
![image](https://github.com/django/asgiref/assets/1457576/9b229c9f-5a9a-4fa1-8370-f094c2965ccc)


<table>
<tr>
 <td>

![image](https://github.com/django/asgiref/assets/1457576/0ea0f3f5-83a2-4660-a438-4d2c2414ce9b)

_before_

 <td>

![Screenshot from 2024-03-22 19-46-13](https://github.com/django/asgiref/assets/1457576/e0647647-44ef-404f-b688-7b1ce8473553)

_after_

</table>