### PR TITLE
Spec: Added `reason` to WebSocket Disconnect

### DIFF
--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -189,6 +189,7 @@ class WebSocketResponseBodyEvent(TypedDict):
 class WebSocketDisconnectEvent(TypedDict):
     type: Literal["websocket.disconnect"]
     code: int
+    reason: Optional[str]
 
 
 class WebSocketCloseEvent(TypedDict):

--- a/specs/www.rst
+++ b/specs/www.rst
@@ -2,7 +2,7 @@
 HTTP & WebSocket ASGI Message Format
 ====================================
 
-**Version**: 2.4 (2024-01-16)
+**Version**: 2.5 (2024-06-05)
 
 The HTTP+WebSocket ASGI sub-specification outlines how to transport HTTP/1.1,
 HTTP/2 and WebSocket connections within ASGI.
@@ -22,6 +22,7 @@ This spec has had the following versions:
 * ``2.2``: Allow ``None`` in the second item of ``server`` scope value.
 * ``2.3``: Added the ``reason`` key to the WebSocket close event.
 * ``2.4``: Calling ``send()`` on a closed connection should raise an error
+* ``2.5``: Added the ``reason`` key to the WebSocket disconnect event.
 
 Spec versions let you understand what the server you are using understands. If
 a server tells you it only supports version ``2.0`` of this spec, then
@@ -456,6 +457,10 @@ Keys:
 * ``code`` (*int*) -- The WebSocket close code, as per the WebSocket spec. If no code
   was received in the frame from the client, the server should set this to ``1005``
   (the default value in the WebSocket specification).
+
+* ``reason`` (*Unicode string*) -- A reason given for the disconnect, can
+  be any string. Optional; if missing or ``None`` default is empty
+  string.
 
 
 Disconnected Client - ``send`` exception


### PR DESCRIPTION
This is a proposal to fix the discussion in #459

Clients can send this reason field when disconnecting. This is allowed as per RFC 6455 and supported in browsers JS API, but previously not supported in ASGI.

---

I took the liberty to bump the spec version, but I can remove it if you prefer 🙂