### PR TITLE
Update HTTP spec: correct `scope.asgi.spec_version`

### DIFF
--- a/specs/www.rst
+++ b/specs/www.rst
@@ -90,8 +90,8 @@ The *connection scope* information passed in ``scope`` contains:
 * ``asgi["version"]`` (*Unicode string*) -- Version of the ASGI spec.
 
 * ``asgi["spec_version"]`` (*Unicode string*) -- Version of the ASGI
-  HTTP spec this server understands; one of ``"2.0"``, ``"2.1"``, ``"2.2"`` or
-  ``"2.3"``. Optional; if missing assume ``2.0``.
+  HTTP spec this server understands; for example: ``"2.0"``, ``"2.1"``, ``"2.2"``,
+  etc. Optional; if missing assume ``"2.0"``.
 
 * ``http_version`` (*Unicode string*) -- One of ``"1.0"``, ``"1.1"`` or ``"2"``.
 


### PR DESCRIPTION
I noticed a tiny gap in the ASGI HTTP spec for `scope["asgi"]["spec_version"]` - all valid versions are explicitly enumerated, but that list hasn't been updated to include newer versions of the ASGI HTTP spec.

This change rewords the spec so the list of versions doesn't need to be updated every time there's a new version of the ASGI HTTP spec. I'd also be happy to just add the newer versions to this list instead, but then someone would also need to remember to update it in the future too.

I tested this by rebuilding the docs locally and viewing the changes in my browser:

![image](https://github.com/user-attachments/assets/248921b9-fa4f-4478-9f19-d28835fd82c4)
