### PR TITLE
Fix #470: Prevent error `AsyncToSync.main_wrap() got multiple values for argument '<kwarg>'`

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -212,13 +212,13 @@ class AsyncToSync(Generic[_P, _R]):
         # main event loop's thread if it's there, otherwise make a new loop
         # in this thread.
         try:
+            partial_fn = functools.partial(self.awaitable, *args, **kwargs)
             awaitable = self.main_wrap(
                 call_result,
                 sys.exc_info(),
                 task_context,
                 context,
-                *args,
-                **kwargs,
+                partial_fn,
             )
 
             if not (self.main_event_loop and self.main_event_loop.is_running()):
@@ -302,8 +302,7 @@ class AsyncToSync(Generic[_P, _R]):
         exc_info: "OptExcInfo",
         task_context: "Optional[List[asyncio.Task[Any]]]",
         context: List[contextvars.Context],
-        *args: _P.args,
-        **kwargs: _P.kwargs,
+        awaitable: Callable[[], Awaitable[_R]],
     ) -> None:
         """
         Wraps the awaitable with something that puts the result into the
@@ -326,9 +325,9 @@ class AsyncToSync(Generic[_P, _R]):
                 try:
                     raise exc_info[1]
                 except BaseException:
-                    result = await self.awaitable(*args, **kwargs)
+                    result = await awaitable()
             else:
-                result = await self.awaitable(*args, **kwargs)
+                result = await awaitable()
         except BaseException as e:
             call_result.set_exception(e)
         else:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4,6 +4,7 @@ import multiprocessing
 import sys
 import threading
 import time
+from typing import Any
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
@@ -1174,3 +1175,28 @@ async def test_inner_shield_sync_and_async_middleware_sync_task():
         assert task_complete
 
     assert task_executed
+
+
+def test_async_to_sync_overlapping_kwargs() -> None:
+    """
+    async_to_sync correctly passes kwargs
+    """
+
+    @async_to_sync
+    async def test_function(**kwargs: Any) -> None:
+        assert kwargs
+
+    test_function(context=1)
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_overlapping_kwargs() -> None:
+    """
+    sync_to_async correctly passes kwargs
+    """
+
+    @sync_to_async
+    def test_function(task_context: int) -> None:
+        assert task_context
+
+    await test_function(task_context=1)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4,10 +4,10 @@ import multiprocessing
 import sys
 import threading
 import time
-from typing import Any
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
+from typing import Any
 from unittest import TestCase
 
 import pytest

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1179,24 +1179,32 @@ async def test_inner_shield_sync_and_async_middleware_sync_task():
 
 def test_async_to_sync_overlapping_kwargs() -> None:
     """
-    async_to_sync correctly passes kwargs
+    Tests that AsyncToSync correctly passes through kwargs to the wrapped function,
+    particularly in the case where the wrapped function uses same names for the parameters
+    as the wrapper.
     """
 
     @async_to_sync
     async def test_function(**kwargs: Any) -> None:
         assert kwargs
 
+    # AsyncToSync.main_wrap has a param named `context`.
+    # So we pass the same argument here to test for the error
+    # "AsyncToSync.main_wrap() got multiple values for argument '<kwarg>'"
     test_function(context=1)
 
 
 @pytest.mark.asyncio
 async def test_sync_to_async_overlapping_kwargs() -> None:
     """
-    sync_to_async correctly passes kwargs
+    Tests that SyncToAsync correctly passes through kwargs to the wrapped function,
+    particularly in the case where the wrapped function uses same names for the parameters
+    as the wrapper.
     """
 
     @sync_to_async
-    def test_function(task_context: int) -> None:
-        assert task_context
+    def test_function(**kwargs: Any) -> None:
+        assert kwargs
 
+    # SyncToAsync.__call__.loop.run_in_executor has a param named `task_context`.
     await test_function(task_context=1)


### PR DESCRIPTION
Fixes #470.

Destructuring `*args` and `**kwargs` passed in by the callee has the chance that the same kwargs names may be used as by `main_wrap`. If that happens, the interpreter will raise a error like: `TypeError: AsyncToSync.main_wrap() got multiple values for argument 'context'`.
`ParamSpec` requires the `*args` and `**kwargs` syntax to be used, but it is wrong execution wise.
So we work around the issue by pre-creating the awaitable outside `main_wrap`, which removes the need to pass `*args` and `**kwargs`.
Another alternative instead of creating the awaitable could be to use `functools.partial`, though that does add some performance overhead: https://github.com/django/asgiref/issues/470#issuecomment-2377074109.