### PR TITLE
Pin mypy for regression in v1.12.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,9 @@ zip_safe = false
 tests =
     pytest
     pytest-asyncio
-    mypy>=0.800
+    # Pending release of https://github.com/python/mypy/pull/17355
+    # Likely in v1.13.1+, when pip can be removed.
+    mypy~=1.11.0
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
See issue: python/mypy#17960
Fixed in master: python/mypy#17355 after last release v1.3.0.


Checks have been failing since mypy 1.12 release: 

```
asgiref/sync.py:291: error: Too few arguments for "__call__" of "AsyncToSync"  [call-arg]
asgiref/sync.py:466: error: Too few arguments for "__call__" of "SyncToAsync"  [call-arg]
```