### PR TITLE
Update mypy pin.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,7 @@ zip_safe = false
 tests =
     pytest
     pytest-asyncio
-    # Pending release of https://github.com/python/mypy/pull/17355
-    # Likely in v1.13.1+, when pip can be removed.
-    mypy~=1.11.0
+    mypy>=1.14.0
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
Regression in mypy v1.12 was resolved in v1.14. Use that as a minimum pin (rather than clearing it) to force/suggest/trigger an update for existing environments.

Follow up to #484.