### PR TITLE
False deadlock detection in case of exception in run_in_executor

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -465,7 +465,7 @@ class SyncToAsync(Generic[_P, _R]):
                     child,
                 ),
             )
-        except:
+        except Exception:
             _restore_context(context)
             self.deadlock_context.set(False)
             raise

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -8,7 +8,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from typing import Any
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 
@@ -195,6 +195,22 @@ async def test_sync_to_async_method_self_attribute():
 
     # Check __self__ has been copied
     assert method.__self__ == instance
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc_cls", (RuntimeError, ValueError, Exception))
+async def test_sync_to_async_broken_executor(exc_cls):
+    """
+    Tests sync_to_async catch error in executor and avoid deadlock
+    """
+    with mock.patch.object(ThreadPoolExecutor, "submit") as mock_run:
+        mock_run.side_effect = exc_cls("Test Error")
+        async_function = sync_to_async(lambda: None, thread_sensitive=True)
+        with pytest.raises(exc_cls, match="Test Error"):
+            await async_function()
+        with pytest.raises(exc_cls, match="Test Error"):
+            await async_function()
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -212,7 +212,6 @@ async def test_sync_to_async_broken_executor(exc_cls):
             await async_function()
 
 
-
 @pytest.mark.asyncio
 async def test_async_to_sync_to_async():
     """


### PR DESCRIPTION
See issue #495 

I suppose this problem can only affect developing/debugging because it should not happen in production.
In my case, the executor was shut down unexpectedly, but I spent time to find the deadlock.
Also, a real exception will be raised only one time, and you will get deadlock detection further, which is more confusing.

However, I have doubts about catching a cancelation error here like in awaiting. A quick review of PEPs didn't answer.
