### PR TITLE
 asgiref.sync trio support 

### DIFF
--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -4,6 +4,7 @@ import contextvars
 import threading
 from typing import Any, Union
 
+
 def _is_asyncio_running():
     try:
         asyncio.get_running_loop()
@@ -12,11 +13,13 @@ def _is_asyncio_running():
     else:
         return True
 
+
 try:
     import sniffio
 except ModuleNotFoundError:
     _is_async = _is_asyncio_running
 else:
+
     def _is_async():
         try:
             sniffio.current_async_library()


### PR DESCRIPTION
this is just a sketch, I've not even tested it on trio yet - just a demo to see approximately how much code needs to change

The design I've gone with is to make as few changes to the asyncio - trio not installed code path as possible, rather than say using anyio and refactoring everything to use a trionic style. I want this to be as minimal and nonintrusive on existing asyncio use cases.

What needs doing is duplicating the test suite with `pytest-trio` (or using anyio's pytest plugin for both) and fixing the mypy errors.

To fix the mypy errors I'll probably want to move the trio versions of the all the util functions into their own private module