### PR TITLE
Require server to handle `Content-Length` headers when `receive`ing HTTP requests

### DIFF
--- a/specs/www.rst
+++ b/specs/www.rst
@@ -23,6 +23,7 @@ This spec has had the following versions:
 * ``2.3``: Added the ``reason`` key to the WebSocket close event.
 * ``2.4``: Calling ``send()`` on a closed connection should raise an error
 * ``2.5``: Added the ``reason`` key to the WebSocket disconnect event.
+* ``2.6``: Added mandatory consistency checks for ``Content-Length`` on HTTP requests.
 
 Spec versions let you understand what the server you are using understands. If
 a server tells you it only supports version ``2.0`` of this spec, then
@@ -174,6 +175,13 @@ Keys:
   application should wait until it gets a chunk with this set to
   ``False``. If ``False``, the request is complete and should be
   processed. Optional; if missing defaults to ``False``.
+
+
+The server *must not* read past the client’s specified ``Content-Length``, and
+*should* simulate an end-of-file condition if the application attempts to read past that
+point. The server *may* respond with an 'HTTP 400 - Bad Request' error code in case the
+request body exceeds the announced content length.
+(This behaviour was introduced in spec version 2.6)
 
 
 Response Start - ``send`` event


### PR DESCRIPTION
Add a clause in the spec that:

- Requires servers to never read past an announced `Content-Length`
- Optionally respond with a `400 - Bad Request` if the actual length exceeds the announced length


## Motivation

### Compatibility with the WSGI spec

As ASGI is a self-described "superset of the WSGI format", it should honour WSGIs stipulation around handling `Content-Length`. [PEP 3333 says](https://peps.python.org/pep-3333/#input-and-error-streams):

> The server is not required to read past the client’s specified Content-Length, and **should** simulate an end-of-file condition if the application attempts to read past that point. The application **should not** attempt to read more data than is specified by the CONTENT_LENGTH variable.

The proposed addition would make ASGI compliant with the WSGI specification in this regard, and adding some additional guarantees by changing the server behaviour from **should** to **must**.


### Confidence for downstream consumers

Currently, ASGI applications can not assume that the `Content-Length` header reflects the actual content length returned by successive calls to `receive()`. This means they can only use the `Content-Length` header as a hint if present, but would need to check its consistency themselves if they want to rely on it. 

Compare this PR where such a feature is discussed: https://github.com/encode/starlette/pull/2328/files#r1397168621
