### PR TITLE
chore: remove not needed anymore typing workaround

### DIFF
--- a/asgiref/current_thread_executor.py
+++ b/asgiref/current_thread_executor.py
@@ -2,7 +2,7 @@ import sys
 import threading
 from collections import deque
 from concurrent.futures import Executor, Future
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
@@ -90,9 +90,10 @@ class CurrentThreadExecutor(Executor):
             work_item.run()
             del work_item
 
-    def _submit(
+    def submit(
         self,
         fn: Callable[_P, _R],
+        /,
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> "Future[_R]":
@@ -120,13 +121,3 @@ class CurrentThreadExecutor(Executor):
 
         # Return the future
         return f
-
-    # Python 3.9+ has a new signature for submit with a "/" after `fn`, to enforce
-    # it to be a positional argument. If we ignore[override] mypy on 3.9+ will be
-    # happy but 3.8 will say that the ignore comment is unused, even when
-    # defining them differently based on sys.version_info.
-    # We should be able to remove this when we drop support for 3.8.
-    if not TYPE_CHECKING:
-
-        def submit(self, fn, *args, **kwargs):
-            return self._submit(fn, *args, **kwargs)


### PR DESCRIPTION
I introduced this workaround in #390 due to the reasons stated in the comment.

As the minimum Python version for this lib is 3.9 now, the workaround can be safely removed