### PR TITLE
fix: prevent deletion of Local values from messing with other ctxs

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -375,3 +375,19 @@ async def test_visibility_task() -> None:
 
     # Changes should not leak to the caller
     assert test_local.value == 0
+
+
+@pytest.mark.asyncio
+async def test_deletion() -> None:
+    """Check visibility with asyncio tasks."""
+    test_local = Local()
+    test_local.value = 123
+
+    async def _test() -> None:
+        # Local is inherited when changing task
+        assert test_local.value == 123
+        del test_local.value
+        assert not hasattr(test_local, "value")
+
+    await asyncio.create_task(_test())
+    assert test_local.value == 123


### PR DESCRIPTION
https://github.com/django/asgiref/commit/85d2445021ff8e588fb2883a865d768b60bd0902#r161477713 changed the `ContextVar` to be a dict of `ContextVars`

While that does work in preventing the contexts to leak, removing a value with `del local.value` completely removes the `ContextVar`, literally unsetting it from all other contexts.

As we discussed [here](https://github.com/django/asgiref/issues/475#issuecomment-3043620092), using `.copy()` is simpler and should have no downsides compared to the current solution, especially since it is a shallow copy only

This PR reverts the mentioned change and instead uses a `.copy()` for both `__setattr__` and `__delattr__`. The added tests there still pass for this solution, and I also added a new test that would have caught this issue.

Fixes #522
Fixes #485