### PR TITLE
Fixed #529: wsgi.errors should be a StringIO

### DIFF
--- a/asgiref/wsgi.py
+++ b/asgiref/wsgi.py
@@ -1,4 +1,4 @@
-from io import StringIO
+import sys
 from tempfile import SpooledTemporaryFile
 
 from asgiref.sync import AsyncToSync, sync_to_async
@@ -67,7 +67,7 @@ class WsgiToAsgiInstance:
             "wsgi.version": (1, 0),
             "wsgi.url_scheme": scope.get("scheme", "http"),
             "wsgi.input": body,
-            "wsgi.errors": StringIO(),
+            "wsgi.errors": sys.stderr,
             "wsgi.multithread": True,
             "wsgi.multiprocess": True,
             "wsgi.run_once": False,


### PR DESCRIPTION
This fixes the direct incompatibility that `wsgi.errors` should be a string-based file object rather than the bytes-based one it has been for 8 years - Flask/werkzeug expects to write to this.

This points it at `sys.stderr` as that's probably the best option ASGI has for this info.