### PR TITLE
Expand information about `receive()` after EOF

### DIFF
--- a/specs/www.rst
+++ b/specs/www.rst
@@ -161,6 +161,11 @@ Note that if the request is being sent using ``Transfer-Encoding: chunked``,
 the server is responsible for handling this encoding. The ``http.request``
 messages should contain just the decoded contents of each chunk.
 
+After the final ``http.request`` message (``more_body`` is ``False``),
+indicating that all data from the declared ``Content-Length`` or decoded
+chunked body has been received, the provided ``receive()`` callable must remain
+awaitable and continue to block until a ``http.disconnect`` event occurs.
+
 Keys:
 
 * ``type`` (*Unicode string*) -- ``"http.request"``.


### PR DESCRIPTION
A brief explanation of how `receive()` behaves after EOF.

This is different from the WSGI approach as in https://github.com/django/asgiref/pull/510. Because we have the advantage of async.

## Why?
Newer implementation tends to make this mistake. After EOF (means all `Content-Length` are consumed), the next `receive()` must not immediately return `http.disconnect` event, but wait/block (async) until real client disconnection.