### PR TITLE
Fix pass callable object to sync_to_async

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+UNRELEASED
+----------
+
+* Fixed a regression in 3.11.0 in ``sync_to_async`` when wrapping a callable
+  with an attribute named ``context``. (#537)
+
 3.11.0 (2025-11-19)
 -------------------
 

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -432,9 +432,11 @@ class SyncToAsync(Generic[_P, _R]):
             or iscoroutinefunction(getattr(func, "__call__", func))
         ):
             raise TypeError("sync_to_async can only be applied to sync functions.")
+
+        functools.update_wrapper(self, func)
         self.func = func
         self.context = context
-        functools.update_wrapper(self, func)
+
         self._thread_sensitive = thread_sensitive
         markcoroutinefunction(self)
         if thread_sensitive and executor is not None:

--- a/tests/test_sync_contextvars.py
+++ b/tests/test_sync_contextvars.py
@@ -138,3 +138,24 @@ def test_async_to_sync_contextvars():
     sync_function = async_to_sync(async_function)
     assert sync_function() == 42
     assert foo.get() == "baz"
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_contextvars_with_callable_with_context_attribute():
+    """
+    Tests that a callable object with a `context` attribute
+    can be wrapped with `sync_to_async` without overwriting the `context` attribute
+    and still returns the expected result.
+    """
+    # Define sync Callable
+    class SyncCallable:
+        def __init__(self):
+            # Should not be copied to the SyncToAsync wrapper.
+            self.context = ...
+
+        def __call__(self):
+            return 42
+
+    async_function = sync_to_async(SyncCallable())
+    assert async_function.context is None
+    assert await async_function() == 42


### PR DESCRIPTION
### Fix: Prevent passing callable objects that overwrite context


This fixes a regression where passing a callable object like huey.Task would break the context attribute.

After this change, huey.Task and similar callables can be used without overwriting context, restoring previous behavior.