### PR TITLE
Added offset and count parameters to pathsend extension

### DIFF
--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -140,6 +140,8 @@ class HTTPResponseTrailersEvent(TypedDict):
 class HTTPResponsePathsendEvent(TypedDict):
     type: Literal["http.response.pathsend"]
     path: str
+    offset: NotRequired[int]
+    count: NotRequired[int]
 
 
 class HTTPServerPushEvent(TypedDict):

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -146,6 +146,22 @@ ASGI servers that implement this extension will provide
         },
     }
 
+Servers that support the ``offset`` and ``count`` parameters for range
+requests must advertise this capability via::
+
+    "scope": {
+        ...
+        "extensions": {
+            "http.response.pathsend": {
+                "ranges": True,
+            },
+        },
+    }
+
+Applications should check for the presence of ``ranges`` before using
+``offset`` and ``count`` parameters. Servers that advertise
+``"ranges": True`` must handle these parameters correctly.
+
 The ASGI framework can initiate a path-send by sending a message with
 the following keys. This message can be sent at any time after the
 *Response Start* message, and cannot be mixed with ``http.response.body``.
@@ -159,6 +175,14 @@ Keys:
 
 * ``path`` (*Unicode string*): The string representation of the absolute
   file path to be sent by the server, platform specific.
+
+* ``offset`` (*int*): Optional. If this value exists, it will specify
+  the offset at which the server starts to read data from ``path``.
+  Otherwise, it will be read from the beginning of the file.
+
+* ``count`` (*int*): Optional. ``count`` is the number of bytes to
+  copy from the file. If omitted, the file will be read from the
+  offset (or beginning) until its end.
 
 The ASGI application itself is responsible to send the relevant headers
 in the *Response Start* message, like the ``Content-Type`` and


### PR DESCRIPTION
### Background Context

I read #469 and discussed with @gi0baro in this thread https://github.com/emmett-framework/granian/discussions/157 about trying to get this as part of the ASGI spec. The implementation here is just a straight copy of the discussion in the relevant thread. It didn't seem that people had too much of a disagreement of what it'd look like, and if we did we could hash it out in this PR.

Links:
- https://github.com/django/asgiref/issues/423: Issue describing problems with the current zerocopysend
- #469: Issue describing potential improvements to pathsend (what this PR implements)
- https://github.com/emmett-framework/granian/discussions/157: discussion that led me to making this PR in this repo

---

(draft)

This extends the `http.response.pathsend` extension to support partial file sends by adding optional offset and count parameters, enabling HTTP Range request support.

The parameters mirror the existing `http.response.zerocopysend` API:
- `offset`: byte position to start reading from (default: beginning)
- `count`: number of bytes to send (default: to end of file)

This allows ASGI frameworks to implement range requests without loading the bytes themselves, offloading the operation to the server.

Servers may advertise range support capability by setting {"ranges": True} in the extension scope dict, allowing frameworks to detect this capability.

The application remains responsible for setting appropriate headers (Content-Range, Content-Length, Accept-Ranges) in the response.

Fixes #469

---

### Implementation

This original [comment](https://github.com/django/asgiref/issues/469#issuecomment-2373742600) also proposed an alternative that uses `range` instead of offset+count. I don't really have strong opinions one way or another about which we use, but I see the trade-offs as:

1. `range` is just one key, and its explicit about the start/end bytes. If we were to do this, we'd need to make a decision about being inclusive/exclusive with the ending byte (I think exclusive ending byte is common in most situations, but http range GETs are inclusive, so we should likely match that: [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests#requesting_a_specific_range_from_a_server))
2. offset/count matches what we have for zerocopysend, so we're staying consistent within ASGI

I'm also in the process of a branch on granian where I'm going to do a quick example implementation just to give an example. I'll likely use granian + starlette to showcase what this extended pathsend could look like

First time contributing to and submitting a PR to asgiref, so please feel free to badger me about bits that I'm missing!