### PR TITLE
Implemented sharing the same event loop with AsyncSingleThreadContext

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
           python -m pip install --upgrade tox tox-py
 
       - name: Run tox targets for ${{ matrix.python-version }}
+        timeout-minutes: 10
         run: tox --py current
 
   lint:


### PR DESCRIPTION
The pull request updates how the `AsyncSingleThreadContext` works in `asgiref.sync` so that multiple `async_to_sync` calls within the same async context share the same asyncio event loop and thread. This improves consistency and correctness when running async code converted to sync repeatedly in one context.