### PR TITLE
Dropped support for Python 3.9.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - 3.9
         - '3.10'
         - '3.11'
         - '3.12'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py310-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 24.10.0
     hooks:
       - id: black
-        args: ["--target-version=py38"]
+        args: ["--target-version=py310"]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.11.5
@@ -18,7 +18,7 @@ repos:
         args: ["--profile=black"]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.0
     hooks:
       - id: flake8
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,8 @@ UNRELEASED
   ``ThreadSensitiveContext`` while its executor thread was still blocked
   waiting on the event loop. (#535)
 
+* Dropped support for EOL Python 3.9.
+
 3.11.1 (2026-02-03)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ file handles for incoming POST bodies).
 Dependencies
 ------------
 
-``asgiref`` requires Python 3.9 or higher.
+``asgiref`` requires Python 3.10 or higher.
 
 
 Contributing

--- a/asgiref/current_thread_executor.py
+++ b/asgiref/current_thread_executor.py
@@ -1,7 +1,8 @@
 import threading
 from collections import deque
+from collections.abc import Callable
 from concurrent.futures import Executor, Future
-from typing import Any, Callable, ParamSpec, TypeVar
+from typing import Any, ParamSpec, TypeVar
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")

--- a/asgiref/current_thread_executor.py
+++ b/asgiref/current_thread_executor.py
@@ -1,13 +1,7 @@
-import sys
 import threading
 from collections import deque
 from concurrent.futures import Executor, Future
-from typing import Any, Callable, TypeVar
-
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
+from typing import Any, Callable, ParamSpec, TypeVar
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -19,6 +19,7 @@ from typing import (
     Generic,
     List,
     Optional,
+    ParamSpec,
     TypeVar,
     Union,
     overload,
@@ -26,11 +27,6 @@ from typing import (
 
 from .current_thread_executor import CurrentThreadExecutor
 from .local import Local
-
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     # This is not available to import at runtime

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -8,20 +8,17 @@ import sys
 import threading
 import warnings
 import weakref
+from collections.abc import Awaitable, Callable, Coroutine
 from concurrent.futures import Future, InvalidStateError, ThreadPoolExecutor
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
-    Callable,
-    Coroutine,
     Dict,
     Generic,
     List,
     Optional,
     ParamSpec,
     TypeVar,
-    Union,
     overload,
 )
 
@@ -186,16 +183,13 @@ class AsyncToSync(Generic[_P, _R]):
         contextvars.ContextVar("async_single_thread_context")
     )
 
-    context_to_thread_executor: "weakref.WeakKeyDictionary[AsyncSingleThreadContext, ThreadPoolExecutor]" = (
-        weakref.WeakKeyDictionary()
-    )
+    context_to_thread_executor: (
+        "weakref.WeakKeyDictionary[AsyncSingleThreadContext, ThreadPoolExecutor]"
+    ) = weakref.WeakKeyDictionary()
 
     def __init__(
         self,
-        awaitable: Union[
-            Callable[_P, Coroutine[Any, Any, _R]],
-            Callable[_P, Awaitable[_R]],
-        ],
+        awaitable: Callable[_P, Coroutine[Any, Any, _R]] | Callable[_P, Awaitable[_R]],
         force_new_loop: bool = False,
     ):
         if not callable(awaitable) or (
@@ -316,9 +310,9 @@ class AsyncToSync(Generic[_P, _R]):
                         ]
                     else:
                         loop_executor = ThreadPoolExecutor(max_workers=1)
-                        self.context_to_thread_executor[
-                            single_thread_context
-                        ] = loop_executor
+                        self.context_to_thread_executor[single_thread_context] = (
+                            loop_executor
+                        )
                 else:
                     # Make our own event loop - in a new thread - and run inside that.
                     loop_executor = ThreadPoolExecutor(max_workers=1)
@@ -348,8 +342,8 @@ class AsyncToSync(Generic[_P, _R]):
         call_result: "Future[_R]",
         exc_info: "OptExcInfo",
         task_context: "Optional[List[asyncio.Task[Any]]]",
-        context: List[contextvars.Context],
-        awaitable: Union[Coroutine[Any, Any, _R], Awaitable[_R]],
+        context: list[contextvars.Context],
+        awaitable: Coroutine[Any, Any, _R] | Awaitable[_R],
     ) -> None:
         """
         Wraps the awaitable with something that puts the result into the
@@ -427,16 +421,16 @@ class SyncToAsync(Generic[_P, _R]):
 
     # Maintaining a weak reference to the context ensures that thread pools are
     # erased once the context goes out of scope. This terminates the thread pool.
-    context_to_thread_executor: "weakref.WeakKeyDictionary[ThreadSensitiveContext, ThreadPoolExecutor]" = (
-        weakref.WeakKeyDictionary()
-    )
+    context_to_thread_executor: (
+        "weakref.WeakKeyDictionary[ThreadSensitiveContext, ThreadPoolExecutor]"
+    ) = weakref.WeakKeyDictionary()
 
     def __init__(
         self,
         func: Callable[_P, _R],
         thread_sensitive: bool = True,
         executor: Optional["ThreadPoolExecutor"] = None,
-        context: Optional[contextvars.Context] = None,
+        context: contextvars.Context | None = None,
     ) -> None:
         if (
             not callable(func)
@@ -499,7 +493,7 @@ class SyncToAsync(Generic[_P, _R]):
         context = contextvars.copy_context() if self.context is None else self.context
         child = functools.partial(self.func, *args, **kwargs)
         func = context.run
-        task_context: List[asyncio.Task[Any]] = []
+        task_context: list[asyncio.Task[Any]] = []
 
         # Run the code in the right thread
         exec_coro = loop.run_in_executor(
@@ -578,40 +572,32 @@ def async_to_sync(
     *,
     force_new_loop: bool = False,
 ) -> Callable[
-    [Union[Callable[_P, Coroutine[Any, Any, _R]], Callable[_P, Awaitable[_R]]]],
+    [Callable[_P, Coroutine[Any, Any, _R]] | Callable[_P, Awaitable[_R]]],
     Callable[_P, _R],
-]:
-    ...
+]: ...
 
 
 @overload
 def async_to_sync(
-    awaitable: Union[
-        Callable[_P, Coroutine[Any, Any, _R]],
-        Callable[_P, Awaitable[_R]],
-    ],
+    awaitable: Callable[_P, Coroutine[Any, Any, _R]] | Callable[_P, Awaitable[_R]],
     *,
     force_new_loop: bool = False,
-) -> Callable[_P, _R]:
-    ...
+) -> Callable[_P, _R]: ...
 
 
 def async_to_sync(
-    awaitable: Optional[
-        Union[
-            Callable[_P, Coroutine[Any, Any, _R]],
-            Callable[_P, Awaitable[_R]],
-        ]
-    ] = None,
+    awaitable: None | (
+        Callable[_P, Coroutine[Any, Any, _R]] | Callable[_P, Awaitable[_R]]
+    ) = None,
     *,
     force_new_loop: bool = False,
-) -> Union[
+) -> (
     Callable[
-        [Union[Callable[_P, Coroutine[Any, Any, _R]], Callable[_P, Awaitable[_R]]]],
+        [Callable[_P, Coroutine[Any, Any, _R]] | Callable[_P, Awaitable[_R]]],
         Callable[_P, _R],
-    ],
-    Callable[_P, _R],
-]:
+    ]
+    | Callable[_P, _R]
+):
     if awaitable is None:
         return lambda f: AsyncToSync(
             f,
@@ -628,9 +614,8 @@ def sync_to_async(
     *,
     thread_sensitive: bool = True,
     executor: Optional["ThreadPoolExecutor"] = None,
-    context: Optional[contextvars.Context] = None,
-) -> Callable[[Callable[_P, _R]], Callable[_P, Coroutine[Any, Any, _R]]]:
-    ...
+    context: contextvars.Context | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, Coroutine[Any, Any, _R]]]: ...
 
 
 @overload
@@ -639,21 +624,20 @@ def sync_to_async(
     *,
     thread_sensitive: bool = True,
     executor: Optional["ThreadPoolExecutor"] = None,
-    context: Optional[contextvars.Context] = None,
-) -> Callable[_P, Coroutine[Any, Any, _R]]:
-    ...
+    context: contextvars.Context | None = None,
+) -> Callable[_P, Coroutine[Any, Any, _R]]: ...
 
 
 def sync_to_async(
-    func: Optional[Callable[_P, _R]] = None,
+    func: Callable[_P, _R] | None = None,
     *,
     thread_sensitive: bool = True,
     executor: Optional["ThreadPoolExecutor"] = None,
-    context: Optional[contextvars.Context] = None,
-) -> Union[
-    Callable[[Callable[_P, _R]], Callable[_P, Coroutine[Any, Any, _R]]],
-    Callable[_P, Coroutine[Any, Any, _R]],
-]:
+    context: contextvars.Context | None = None,
+) -> (
+    Callable[[Callable[_P, _R]], Callable[_P, Coroutine[Any, Any, _R]]]
+    | Callable[_P, Coroutine[Any, Any, _R]]
+):
     if func is None:
         return lambda f: SyncToAsync(
             f,

--- a/asgiref/timeout.py
+++ b/asgiref/timeout.py
@@ -10,7 +10,7 @@ import asyncio
 import warnings
 from types import TracebackType
 from typing import Any  # noqa
-from typing import Optional, Type
+from typing import Optional  # noqa
 
 
 class timeout:
@@ -30,9 +30,9 @@ class timeout:
 
     def __init__(
         self,
-        timeout: Optional[float],
+        timeout: float | None,
         *,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
+        loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         self._timeout = timeout
         if loop is None:
@@ -52,10 +52,10 @@ class timeout:
 
     def __exit__(
         self,
-        exc_type: Type[BaseException],
+        exc_type: type[BaseException],
         exc_val: BaseException,
         exc_tb: TracebackType,
-    ) -> Optional[bool]:
+    ) -> bool | None:
         self._do_exit(exc_type)
         return None
 
@@ -64,7 +64,7 @@ class timeout:
 
     async def __aexit__(
         self,
-        exc_type: Type[BaseException],
+        exc_type: type[BaseException],
         exc_val: BaseException,
         exc_tb: TracebackType,
     ) -> None:
@@ -75,7 +75,7 @@ class timeout:
         return self._cancelled
 
     @property
-    def remaining(self) -> Optional[float]:
+    def remaining(self) -> float | None:
         if self._cancel_at is not None:
             return max(self._cancel_at - self._loop.time(), 0.0)
         else:
@@ -101,7 +101,7 @@ class timeout:
         self._cancel_handler = self._loop.call_at(self._cancel_at, self._cancel_task)
         return self
 
-    def _do_exit(self, exc_type: Type[BaseException]) -> None:
+    def _do_exit(self, exc_type: type[BaseException]) -> None:
         if exc_type is asyncio.CancelledError and self._cancelled:
             self._cancel_handler = None
             self._task = None

--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -1,18 +1,6 @@
 import sys
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    Iterable,
-    Literal,
-    Optional,
-    Protocol,
-    Tuple,
-    Type,
-    TypedDict,
-    Union,
-)
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, Literal, Protocol, TypedDict, Union
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired
@@ -60,7 +48,7 @@ __all__ = (
 
 class ASGIVersions(TypedDict):
     spec_version: str
-    version: Union[Literal["2.0"], Literal["3.0"]]
+    version: Literal["2.0"] | Literal["3.0"]
 
 
 class HTTPScope(TypedDict):
@@ -73,11 +61,11 @@ class HTTPScope(TypedDict):
     raw_path: bytes
     query_string: bytes
     root_path: str
-    headers: Iterable[Tuple[bytes, bytes]]
-    client: Optional[Tuple[str, int]]
-    server: Optional[Tuple[str, Optional[int]]]
-    state: NotRequired[Dict[str, Any]]
-    extensions: Optional[Dict[str, Dict[object, object]]]
+    headers: Iterable[tuple[bytes, bytes]]
+    client: tuple[str, int] | None
+    server: tuple[str, int | None] | None
+    state: NotRequired[dict[str, Any]]
+    extensions: dict[str, dict[object, object]] | None
 
 
 class WebSocketScope(TypedDict):
@@ -89,18 +77,18 @@ class WebSocketScope(TypedDict):
     raw_path: bytes
     query_string: bytes
     root_path: str
-    headers: Iterable[Tuple[bytes, bytes]]
-    client: Optional[Tuple[str, int]]
-    server: Optional[Tuple[str, Optional[int]]]
+    headers: Iterable[tuple[bytes, bytes]]
+    client: tuple[str, int] | None
+    server: tuple[str, int | None] | None
     subprotocols: Iterable[str]
-    state: NotRequired[Dict[str, Any]]
-    extensions: Optional[Dict[str, Dict[object, object]]]
+    state: NotRequired[dict[str, Any]]
+    extensions: dict[str, dict[object, object]] | None
 
 
 class LifespanScope(TypedDict):
     type: Literal["lifespan"]
     asgi: ASGIVersions
-    state: NotRequired[Dict[str, Any]]
+    state: NotRequired[dict[str, Any]]
 
 
 WWWScope = Union[HTTPScope, WebSocketScope]
@@ -115,13 +103,13 @@ class HTTPRequestEvent(TypedDict):
 
 class HTTPResponseDebugEvent(TypedDict):
     type: Literal["http.response.debug"]
-    info: Dict[str, object]
+    info: dict[str, object]
 
 
 class HTTPResponseStartEvent(TypedDict):
     type: Literal["http.response.start"]
     status: int
-    headers: Iterable[Tuple[bytes, bytes]]
+    headers: Iterable[tuple[bytes, bytes]]
     trailers: bool
 
 
@@ -133,7 +121,7 @@ class HTTPResponseBodyEvent(TypedDict):
 
 class HTTPResponseTrailersEvent(TypedDict):
     type: Literal["http.response.trailers"]
-    headers: Iterable[Tuple[bytes, bytes]]
+    headers: Iterable[tuple[bytes, bytes]]
     more_trailers: bool
 
 
@@ -145,7 +133,7 @@ class HTTPResponsePathsendEvent(TypedDict):
 class HTTPServerPushEvent(TypedDict):
     type: Literal["http.response.push"]
     path: str
-    headers: Iterable[Tuple[bytes, bytes]]
+    headers: Iterable[tuple[bytes, bytes]]
 
 
 class HTTPDisconnectEvent(TypedDict):
@@ -158,26 +146,26 @@ class WebSocketConnectEvent(TypedDict):
 
 class WebSocketAcceptEvent(TypedDict):
     type: Literal["websocket.accept"]
-    subprotocol: Optional[str]
-    headers: Iterable[Tuple[bytes, bytes]]
+    subprotocol: str | None
+    headers: Iterable[tuple[bytes, bytes]]
 
 
 class WebSocketReceiveEvent(TypedDict):
     type: Literal["websocket.receive"]
-    bytes: Optional[bytes]
-    text: Optional[str]
+    bytes: bytes | None
+    text: str | None
 
 
 class WebSocketSendEvent(TypedDict):
     type: Literal["websocket.send"]
-    bytes: Optional[bytes]
-    text: Optional[str]
+    bytes: bytes | None
+    text: str | None
 
 
 class WebSocketResponseStartEvent(TypedDict):
     type: Literal["websocket.http.response.start"]
     status: int
-    headers: Iterable[Tuple[bytes, bytes]]
+    headers: Iterable[tuple[bytes, bytes]]
 
 
 class WebSocketResponseBodyEvent(TypedDict):
@@ -189,13 +177,13 @@ class WebSocketResponseBodyEvent(TypedDict):
 class WebSocketDisconnectEvent(TypedDict):
     type: Literal["websocket.disconnect"]
     code: int
-    reason: Optional[str]
+    reason: str | None
 
 
 class WebSocketCloseEvent(TypedDict):
     type: Literal["websocket.close"]
     code: int
-    reason: Optional[str]
+    reason: str | None
 
 
 class LifespanStartupEvent(TypedDict):
@@ -258,16 +246,14 @@ ASGISendCallable = Callable[[ASGISendEvent], Awaitable[None]]
 
 
 class ASGI2Protocol(Protocol):
-    def __init__(self, scope: Scope) -> None:
-        ...
+    def __init__(self, scope: Scope) -> None: ...
 
     async def __call__(
         self, receive: ASGIReceiveCallable, send: ASGISendCallable
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
-ASGI2Application = Type[ASGI2Protocol]
+ASGI2Application = type[ASGI2Protocol]
 ASGI3Application = Callable[
     [
         Scope,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from typing import Dict, List
 
 #
 # ASGI documentation build configuration file, created by
@@ -32,10 +31,10 @@ from typing import Dict, List
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions: List[str] = []
+extensions: list[str] = []
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path: List[str] = []
+templates_path: list[str] = []
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -95,7 +94,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path: List[str] = []
+html_static_path: list[str] = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -121,7 +120,7 @@ htmlhelp_basename = "ASGIdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements: Dict[str, str] = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -29,7 +28,7 @@ project_urls =
     Changelog = https://github.com/django/asgiref/blob/master/CHANGELOG.txt
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.10
 packages = find:
 include_package_data = true
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ asyncio_default_fixture_loop_scope=function
 
 [flake8]
 exclude = venv/*,tox/*,specs/*
-ignore = E123,E128,E266,E402,W503,E731,W601,E203
+ignore = E123,E128,E266,E402,E704,W503,E731,W601,E203
 max-line-length = 119
 
 [isort]

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -29,6 +29,7 @@ async def test_sync_to_async():
     Tests we can call sync functions from an async thread
     (even if the number of thread workers is less than the number of calls)
     """
+
     # Define sync function
     def sync_function():
         time.sleep(1)
@@ -125,6 +126,7 @@ async def test_sync_to_async_decorator():
     """
     Tests sync_to_async as a decorator
     """
+
     # Define sync function
     @sync_to_async
     def test_function():
@@ -164,6 +166,7 @@ async def test_sync_to_async_method_decorator():
     """
     Tests sync_to_async as a method decorator
     """
+
     # Define sync function
     class TestClass:
         @sync_to_async
@@ -465,6 +468,7 @@ def test_async_to_sync_method_self_attribute():
     """
     Tests async_to_sync on a method copies __self__.
     """
+
     # Define async function.
     class TestClass:
         async def test_function(self):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -256,7 +256,6 @@ async def test_async_to_sync_to_async_decorator():
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9")
 async def test_async_to_sync_to_thread_decorator():
     """
     Test async_to_sync as a function decorator uses the outer thread

--- a/tests/test_sync_contextvars.py
+++ b/tests/test_sync_contextvars.py
@@ -41,6 +41,7 @@ async def test_sync_to_async_contextvars():
     present in the called context, and that any changes in the called context
     are then propagated back to the calling context.
     """
+
     # Define sync function
     def sync_function():
         time.sleep(1)
@@ -125,6 +126,7 @@ def test_async_to_sync_contextvars():
     present in the called context, and that any changes in the called context
     are then propagated back to the calling context.
     """
+
     # Define async function
     async def async_function():
         await asyncio.sleep(1)
@@ -147,6 +149,7 @@ async def test_sync_to_async_contextvars_with_callable_with_context_attribute():
     can be wrapped with `sync_to_async` without overwriting the `context` attribute
     and still returns the expected result.
     """
+
     # Define sync Callable
     class SyncCallable:
         def __init__(self):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -11,6 +11,7 @@ async def test_receive_nothing():
     """
     Tests ApplicationCommunicator.receive_nothing to return the correct value.
     """
+
     # Get an ApplicationCommunicator instance
     def wsgi_application(environ, start_response):
         start_response("200 OK", [])
@@ -51,6 +52,7 @@ def test_receive_nothing_lazy_loop():
     """
     Tests ApplicationCommunicator.receive_nothing to return the correct value.
     """
+
     # Get an ApplicationCommunicator instance
     def wsgi_application(environ, start_response):
         start_response("200 OK", [])

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312,313,314}-{test,mypy}
+    py{310,311,312,313,314}-{test,mypy}
     qa
 
 [testenv]


### PR DESCRIPTION
Hi! :wave:

Resuscitating #506

Only bumped the linters as far as necessary to avoid crashes on 3.14 for removed `ast.Str`.

Hope this is helpful.