### PR TITLE
Speed up `Local`

### DIFF
--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -1,5 +1,5 @@
 import asyncio
-import contextlib
+from contextlib import nullcontext
 import contextvars
 import threading
 from typing import Any, Union
@@ -77,6 +77,23 @@ class _CVar:
             raise AttributeError(f"{self!r} object has no attribute {key!r}")
 
 
+class _LockContext:
+    """Context manager that acquires a lock and yields a value."""
+
+    __slots__ = ("_lock", "_value")
+
+    def __init__(self, lock: threading.RLock, value: Any) -> None:
+        self._lock = lock
+        self._value = value
+
+    def __enter__(self):
+        self._lock.acquire()
+        return self._value
+
+    def __exit__(self, *exc_info):
+        self._lock.release()
+
+
 class Local:
     """Local storage for async tasks.
 
@@ -117,8 +134,8 @@ class Local:
         else:
             # Contextvar storage
             self._storage = _CVar()
+            self._lock_context = _LockContext(self._thread_lock, self._storage)
 
-    @contextlib.contextmanager
     def _lock_storage(self):
         # Thread safe access to storage
         if self._thread_critical:
@@ -135,7 +152,7 @@ class Local:
                 # just the plain thread local (i.e, "global within
                 # this thread" - it doesn't matter where you are
                 # in a call stack you see the same storage)
-                yield self._storage
+                return nullcontext(self._storage)
             else:
                 # We are in an async thread - storage is still
                 # local to this thread, but additionally should
@@ -149,19 +166,18 @@ class Local:
                 # self._storage is a thread local, so the members
                 # can't be accessed in another thread (we don't
                 # need any locks)
-                yield self._storage.cvar
+                return nullcontext(self._storage.cvar)
         else:
             # Lock for thread_critical=False as other threads
             # can access the exact same storage object
-            with self._thread_lock:
-                yield self._storage
+            return self._lock_context
 
     def __getattr__(self, key):
         with self._lock_storage() as storage:
             return getattr(storage, key)
 
     def __setattr__(self, key, value):
-        if key in ("_local", "_storage", "_thread_critical", "_thread_lock"):
+        if key in ("_local", "_storage", "_thread_critical", "_thread_lock", "_lock_context"):
             return super().__setattr__(key, value)
         with self._lock_storage() as storage:
             setattr(storage, key, value)

--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -34,13 +34,16 @@ def _rehome(storage: "_Storage") -> "_Storage":
     return _Storage(threading.get_ident(), storage.data)
 
 
+_object_setattr = object.__setattr__
+
+
 class _CVar:
     """Storage utility for Local."""
 
+    _data: "contextvars.ContextVar[_Storage]"
+
     def __init__(self) -> None:
-        self._data: "contextvars.ContextVar[_Storage]" = contextvars.ContextVar(
-            "asgiref.local"
-        )
+        _object_setattr(self, "_data", contextvars.ContextVar("asgiref.local"))
 
     def _storage(self) -> "_Storage":
         # Only return storage that belongs to the current thread. Storage with
@@ -59,7 +62,7 @@ class _CVar:
 
     def __setattr__(self, key: str, value: Any) -> None:
         if key == "_data":
-            return super().__setattr__(key, value)
+            raise AttributeError("Cannot set attribute '_data' on Local")
 
         data = self._storage().data.copy()
         data[key] = value

--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -76,26 +76,6 @@ class _CVar:
             raise AttributeError(f"{self!r} object has no attribute {key!r}")
 
 
-class _LockContext:
-    """Context manager that acquires a lock and yields a value."""
-
-    __slots__ = ("_lock", "_value")
-
-    def __init__(self, lock: threading.RLock, value: Any) -> None:
-        self._lock = lock
-        self._value = value
-
-    def __enter__(self):
-        self._lock.acquire()
-        return self._value
-
-    def __exit__(self, *exc_info):
-        self._lock.release()
-
-
-_object_setattr = object.__setattr__
-
-
 class Local:
     """Local storage for async tasks.
 
@@ -152,21 +132,32 @@ class _DefaultLocal(Local):
     def __init__(self, thread_critical: bool = False) -> None:
         super().__init__(thread_critical)
         storage = _CVar()
-        lock = threading.RLock()
+        _object_setattr(self, "_lock", threading.RLock())
         _object_setattr(self, "_storage", storage)
-        _object_setattr(self, "_lock_context", _LockContext(lock, storage))
 
     def __getattr__(self, key):
-        with self._lock_context as storage:
-            return getattr(storage, key)
+        # Lock acquisition inlined here for performance reasons.
+        self._lock.acquire()
+        try:
+            return getattr(self._storage, key)
+        finally:
+            self._lock.release()
 
     def __setattr__(self, key, value):
-        with self._lock_context as storage:
-            setattr(storage, key, value)
+        # Lock acquisition inlined here for performance reasons.
+        self._lock.acquire()
+        try:
+            setattr(self._storage, key, value)
+        finally:
+            self._lock.release()
 
     def __delattr__(self, key):
-        with self._lock_context as storage:
-            delattr(storage, key)
+        # Lock acquisition inlined here for performance reasons.
+        self._lock.acquire()
+        try:
+            delattr(self._storage, key)
+        finally:
+            self._lock.release()
 
 
 class _ThreadCriticalLocal(Local):

--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -1,8 +1,7 @@
 import asyncio
-from contextlib import nullcontext
 import contextvars
 import threading
-from typing import Any, Union
+from typing import Any
 
 
 class _Storage:
@@ -94,6 +93,9 @@ class _LockContext:
         self._lock.release()
 
 
+_object_setattr = object.__setattr__
+
+
 class Local:
     """Local storage for async tasks.
 
@@ -122,66 +124,87 @@ class Local:
     Unlike plain `contextvars` objects, this utility is threadsafe.
     """
 
-    def __init__(self, thread_critical: bool = False) -> None:
-        self._thread_critical = thread_critical
-        self._thread_lock = threading.RLock()
-
-        self._storage: "Union[threading.local, _CVar]"
-
+    def __new__(cls, thread_critical: bool = False) -> "Local":
+        # Make `Local(...)` actually instantiate either of the specialized subclasses.
         if thread_critical:
-            # Thread-local storage
-            self._storage = threading.local()
-        else:
-            # Contextvar storage
-            self._storage = _CVar()
-            self._lock_context = _LockContext(self._thread_lock, self._storage)
+            return object.__new__(_ThreadCriticalLocal)
+        return object.__new__(_DefaultLocal)
 
-    def _lock_storage(self):
-        # Thread safe access to storage
-        if self._thread_critical:
-            is_async = True
-            try:
-                # this is a test for are we in a async or sync
-                # thread - will raise RuntimeError if there is
-                # no current loop
-                asyncio.get_running_loop()
-            except RuntimeError:
-                is_async = False
-            if not is_async:
-                # We are in a sync thread, the storage is
-                # just the plain thread local (i.e, "global within
-                # this thread" - it doesn't matter where you are
-                # in a call stack you see the same storage)
-                return nullcontext(self._storage)
-            else:
-                # We are in an async thread - storage is still
-                # local to this thread, but additionally should
-                # behave like a context var (is only visible with
-                # the same async call stack)
+    def __init__(self, thread_critical: bool = False) -> None:
+        # `thread_critical` is not really used here;
+        # this just marks the __init__ interface for
+        # the concrete specialized subclasses.
+        pass
 
-                # Ensure context exists in the current thread
-                if not hasattr(self._storage, "cvar"):
-                    self._storage.cvar = _CVar()
+    # These mark this class as magical to Mypy; the real implementations
+    # are in the concrete subclasses below.
 
-                # self._storage is a thread local, so the members
-                # can't be accessed in another thread (we don't
-                # need any locks)
-                return nullcontext(self._storage.cvar)
-        else:
-            # Lock for thread_critical=False as other threads
-            # can access the exact same storage object
-            return self._lock_context
+    def __getattr__(self, key: str) -> Any: ...
+
+    def __setattr__(self, key: str, value: Any) -> Any: ...
+
+    def __delattr__(self, key: str) -> Any: ...
+
+
+class _DefaultLocal(Local):
+    """Local with thread_critical=False: CVar storage protected by a lock."""
+
+    def __init__(self, thread_critical: bool = False) -> None:
+        super().__init__(thread_critical)
+        storage = _CVar()
+        lock = threading.RLock()
+        _object_setattr(self, "_storage", storage)
+        _object_setattr(self, "_lock_context", _LockContext(lock, storage))
 
     def __getattr__(self, key):
-        with self._lock_storage() as storage:
+        with self._lock_context as storage:
             return getattr(storage, key)
 
     def __setattr__(self, key, value):
-        if key in ("_local", "_storage", "_thread_critical", "_thread_lock", "_lock_context"):
-            return super().__setattr__(key, value)
-        with self._lock_storage() as storage:
+        with self._lock_context as storage:
             setattr(storage, key, value)
 
     def __delattr__(self, key):
-        with self._lock_storage() as storage:
+        with self._lock_context as storage:
             delattr(storage, key)
+
+
+class _ThreadCriticalLocal(Local):
+    """Local with thread_critical=True: thread-local storage, CVar in async."""
+
+    def __init__(self, thread_critical: bool = False) -> None:
+        super().__init__(thread_critical)
+        _object_setattr(self, "_storage", threading.local())
+
+    def _get_storage(self):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # We are in a sync thread, the storage is
+            # just the plain thread local (i.e, "global within
+            # this thread" - it doesn't matter where you are
+            # in a call stack you see the same storage)
+            return self._storage
+
+        # We are in an async thread - storage is still
+        # local to this thread, but additionally should
+        # behave like a context var (is only visible with
+        # the same async call stack)
+
+        # Ensure context exists in the current thread
+        if not hasattr(self._storage, "cvar"):
+            self._storage.cvar = _CVar()
+
+        # self._storage is a thread local, so the members
+        # can't be accessed in another thread (we don't
+        # need any locks)
+        return self._storage.cvar
+
+    def __getattr__(self, key):
+        return getattr(self._get_storage(), key)
+
+    def __setattr__(self, key, value):
+        setattr(self._get_storage(), key, value)
+
+    def __delattr__(self, key):
+        delattr(self._get_storage(), key)

--- a/tests/test_benchmark_local.py
+++ b/tests/test_benchmark_local.py
@@ -1,0 +1,117 @@
+import asyncio
+from collections.abc import Callable, Generator
+from importlib.util import find_spec
+from typing import Any, Protocol
+
+import pytest
+
+from asgiref.local import Local
+
+
+class BenchmarkFixture(Protocol):
+    def __call__(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None: ...
+
+
+if not (find_spec("pytest_benchmark") or find_spec("pytest_codspeed")):
+    pytest.skip("pytest-benchmark or pytest-codspeed required", allow_module_level=True)
+
+
+# -- Sync, thread_critical=False (lock + CVar path) --
+
+
+@pytest.fixture
+def local_default() -> Local:
+    return Local(thread_critical=False)
+
+
+@pytest.fixture
+def local_thread_critical() -> Local:
+    return Local(thread_critical=True)
+
+
+@pytest.fixture
+def event_loop() -> Generator[asyncio.AbstractEventLoop]:
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def test_getattr_default(benchmark: BenchmarkFixture, local_default: Local) -> None:
+    local_default.x = 1
+    benchmark(getattr, local_default, "x")
+
+
+def test_setattr_default(benchmark: BenchmarkFixture, local_default: Local) -> None:
+    benchmark(setattr, local_default, "x", 1)
+
+
+def test_delattr_default(benchmark: BenchmarkFixture, local_default: Local) -> None:
+    def del_cycle() -> None:
+        local_default.x = 1
+        del local_default.x
+
+    benchmark(del_cycle)
+
+
+def test_getattr_missing_default(
+    benchmark: BenchmarkFixture, local_default: Local
+) -> None:
+    def get_missing() -> None:
+        try:
+            local_default.x
+        except AttributeError:
+            pass
+
+    benchmark(get_missing)
+
+
+# -- Sync, thread_critical=True (thread-local path, no async loop) --
+
+
+def test_getattr_thread_critical(
+    benchmark: BenchmarkFixture, local_thread_critical: Local
+) -> None:
+    local_thread_critical.x = 1
+    benchmark(getattr, local_thread_critical, "x")
+
+
+def test_setattr_thread_critical(
+    benchmark: BenchmarkFixture, local_thread_critical: Local
+) -> None:
+    benchmark(setattr, local_thread_critical, "x", 1)
+
+
+def test_delattr_thread_critical(
+    benchmark: BenchmarkFixture, local_thread_critical: Local
+) -> None:
+    def del_cycle() -> None:
+        local_thread_critical.x = 1
+        del local_thread_critical.x
+
+    benchmark(del_cycle)
+
+
+# -- Async, thread_critical=True (thread-local + CVar path) --
+
+
+def test_getattr_thread_critical_async(
+    benchmark: BenchmarkFixture, event_loop: asyncio.AbstractEventLoop
+) -> None:
+    local = Local(thread_critical=True)
+
+    async def do_get() -> Any:
+        local.x = 1
+        return local.x
+
+    benchmark(lambda: event_loop.run_until_complete(do_get()))
+
+
+def test_setattr_thread_critical_async(
+    benchmark: BenchmarkFixture, event_loop: asyncio.AbstractEventLoop
+) -> None:
+    local = Local(thread_critical=True)
+
+    async def do_set() -> None:
+        local.x = 1
+
+    benchmark(lambda: event_loop.run_until_complete(do_set()))

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -27,6 +27,9 @@ async def test_local_task():
     del test_local.foo
     with pytest.raises(AttributeError):
         test_local.foo
+    # Delete again now that it's already gone
+    with pytest.raises(AttributeError):
+        del test_local.foo
 
 
 def test_local_thread():
@@ -232,6 +235,9 @@ async def test_local_critical_no_task_to_thread():
             test_local.foo
         test_local.foo = "secret"
         assert test_local.foo == "secret"
+        del test_local.foo
+        with pytest.raises(AttributeError):
+            del test_local.foo
 
     await sync_to_async(sync_function)()
     # Check the value outside is not touched
@@ -419,7 +425,7 @@ async def test_visibility_task() -> None:
 
 @pytest.mark.asyncio
 async def test_deletion() -> None:
-    """Check visibility with asyncio tasks."""
+    """Check visibility of deletions with asyncio tasks."""
     test_local = Local()
     test_local.value = 123
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -431,3 +431,13 @@ async def test_deletion() -> None:
 
     await asyncio.create_task(_test())
     assert test_local.value == 123
+
+
+def test_data_name_protected() -> None:
+    test_local = Local()
+    test_local.important = "keep me"
+    # ``_data`` is the name ``_CVar`` uses for its backing ContextVar,
+    # so it may not be set by user code.
+    with pytest.raises(AttributeError):
+        test_local._data = "user supplied value"
+    assert test_local.important == "keep me"

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -6,7 +6,7 @@ from threading import Thread
 
 import pytest
 
-from asgiref.local import Local
+from asgiref.local import Local, _DefaultLocal, _ThreadCriticalLocal
 from asgiref.sync import async_to_sync, sync_to_async
 
 
@@ -441,3 +441,13 @@ def test_data_name_protected() -> None:
     with pytest.raises(AttributeError):
         test_local._data = "user supplied value"
     assert test_local.important == "keep me"
+
+
+def test_new_returns_specialized_subclass() -> None:
+    default = Local()
+    tc = Local(thread_critical=True)
+    assert type(default) is _DefaultLocal
+    assert type(tc) is _ThreadCriticalLocal
+    assert isinstance(default, Local)
+    assert isinstance(tc, Local)
+    assert type(tc) is not type(default)  # type: ignore[comparison-overlap]


### PR DESCRIPTION
While profiling a Django app with [viztracer](https://github.com/gaogaotiantian/viztracer/), I noticed `asgiref` Local access/locking being actually visible in the trace, and figured there could be something to fix perf-wise :)

`@contextlib.contextmanager` can be slow due to the fact that the interpreter needs to juggle a generator frame, etc. <del>This PR replaces it with a small real context manager (that is stored on the instance for reuse instead, in the first commit.</del>

The second commit further specializes `Local` (using `__new__` magic, so this is transparent to consumers) to 2 classes depending on if `thread_critical` is set, so accesses do not require branches at all – and indeed, in the thread-critical case, `nullcontext` isn't required anymore. (Further, the guards in the `setattr` case become unnecessary since we can just use `object.__setattr__` to sidestep the classes' impls.)

EDIT: the third commit gets rid of the context manager altogether in favor of just inlining the same things as a `try:finally:` block, as per comments here, for even more performance. 😄 


I [pytest-benchmarked](https://gist.github.com/akx/00fa4559aabd4d890465ebb4489566bf) this to be pleasantly faster (and given that these are often very hot paths in Django, this is a nice win for not an awful lot of additional code):

## Real context manager

| Benchmark | Kops/s before | Kops/s after | Change |
|---|--:|--:|--:|
| `test_getattr_thread_critical` | 1,041.50 | 3,715.52 | **+257%** |
| `test_setattr_thread_critical` | 1,040.11 | 3,575.43 | **+244%** |
| `test_getattr_default` | 1,034.84 | 2,493.43 | **+141%** |
| `test_setattr_default` | 913.03 | 1,833.74 | **+101%** |
| `test_delattr_thread_critical` | 504.15 | 1,747.49 | **+247%** |
| `test_getattr_missing_default` | 544.32 | 968.90 | **+78%** |
| `test_delattr_default` | 444.68 | 1,030.41 | **+132%** |
| `test_getattr_thread_critical_async` | 31.40 | 32.50 | +4% |
| `test_setattr_thread_critical_async` | 32.69 | 33.34 | +2% |

## No context manager (only affects `default`)

| Benchmark | Kops/s before | Kops/s after | Change |
|---|---:|---:|---:|
| test_getattr_thread_critical           |                   1,047.4632 |                3,649.6306 |       +248.4% |
| test_setattr_thread_critical           |                   1,013.8543 |                3,500.2482 |       +245.2% |
| test_getattr_default                   |                     986.0904 |                3,586.0984 |       +263.7% |
| test_setattr_default                   |                     859.1037 |                2,673.6265 |       +211.2% |
| test_getattr_missing_default           |                     520.0822 |                1,068.1260 |       +105.4% |
| test_delattr_thread_critical           |                     502.1324 |                1,712.0688 |       +241.0% |
| test_delattr_default                   |                     423.2087 |                1,347.7917 |       +218.5% |
| test_setattr_thread_critical_async     |                      31.4873 |                   32.1533 |        +2.1% |
| test_getattr_thread_critical_async     |                      30.7843 |                   31.7018 |        +3.0% |
