### PR TITLE
Fix #514: Handle scope["server"] = None in build_environ without crashing

### DIFF
--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -75,7 +75,7 @@ class HTTPScope(TypedDict):
     root_path: str
     headers: Iterable[Tuple[bytes, bytes]]
     client: Optional[Tuple[str, int]]
-    server: NotRequired[Optional[Tuple[str, Optional[int]]]]
+    server: Optional[Tuple[str, Optional[int]]]    
     state: NotRequired[Dict[str, Any]]
     extensions: Optional[Dict[str, Dict[object, object]]]
 
@@ -91,7 +91,7 @@ class WebSocketScope(TypedDict):
     root_path: str
     headers: Iterable[Tuple[bytes, bytes]]
     client: Optional[Tuple[str, int]]
-    server: NotRequired[Optional[Tuple[str, Optional[int]]]]
+    server: Optional[Tuple[str, Optional[int]]]    
     subprotocols: Iterable[str]
     state: NotRequired[Dict[str, Any]]
     extensions: Optional[Dict[str, Dict[object, object]]]

--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -75,7 +75,7 @@ class HTTPScope(TypedDict):
     root_path: str
     headers: Iterable[Tuple[bytes, bytes]]
     client: Optional[Tuple[str, int]]
-    server: Optional[Tuple[str, Optional[int]]]
+    server: NotRequired[Optional[Tuple[str, Optional[int]]]]
     state: NotRequired[Dict[str, Any]]
     extensions: Optional[Dict[str, Dict[object, object]]]
 
@@ -91,7 +91,7 @@ class WebSocketScope(TypedDict):
     root_path: str
     headers: Iterable[Tuple[bytes, bytes]]
     client: Optional[Tuple[str, int]]
-    server: Optional[Tuple[str, Optional[int]]]
+    server: NotRequired[Optional[Tuple[str, Optional[int]]]]
     subprotocols: Iterable[str]
     state: NotRequired[Dict[str, Any]]
     extensions: Optional[Dict[str, Dict[object, object]]]

--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -75,7 +75,7 @@ class HTTPScope(TypedDict):
     root_path: str
     headers: Iterable[Tuple[bytes, bytes]]
     client: Optional[Tuple[str, int]]
-    server: Optional[Tuple[str, Optional[int]]]    
+    server: Optional[Tuple[str, Optional[int]]]
     state: NotRequired[Dict[str, Any]]
     extensions: Optional[Dict[str, Dict[object, object]]]
 
@@ -91,7 +91,7 @@ class WebSocketScope(TypedDict):
     root_path: str
     headers: Iterable[Tuple[bytes, bytes]]
     client: Optional[Tuple[str, int]]
-    server: Optional[Tuple[str, Optional[int]]]    
+    server: Optional[Tuple[str, Optional[int]]]
     subprotocols: Iterable[str]
     state: NotRequired[Dict[str, Any]]
     extensions: Optional[Dict[str, Dict[object, object]]]

--- a/asgiref/wsgi.py
+++ b/asgiref/wsgi.py
@@ -78,9 +78,10 @@ class WsgiToAsgiInstance:
             "wsgi.run_once": False,
         }
         # Get server name and port - required in WSGI, not in ASGI
-        if "server" in scope:
-            environ["SERVER_NAME"] = scope["server"][0]
-            environ["SERVER_PORT"] = str(scope["server"][1])
+        server = scope.get("server")
+        if server is not None:
+            environ["SERVER_NAME"] = server[0]
+            environ["SERVER_PORT"] = str(server[1] if server[1] is not None else 0)
         else:
             environ["SERVER_NAME"] = "localhost"
             environ["SERVER_PORT"] = "80"

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -77,6 +77,104 @@ def test_script_name():
 
 
 @pytest.mark.asyncio
+async def test_build_environ_server_none():
+    """
+    Ensure build_environ handles scope["server"] = None without crashing
+    and falls back to localhost:80 (as per existing default).
+    """
+    def dummy_app(environ, start_response):
+        assert environ["SERVER_NAME"] == "localhost"
+        assert environ["SERVER_PORT"] == "80"
+        start_response("200 OK", [])
+        return [b"OK"]
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "server": None,  # Reproduces Uvicorn Unix socket behavior
+        "headers": [],
+    }
+
+    instance = WsgiToAsgiInstance(dummy_app)
+    environ = instance.build_environ(scope, b"")
+    # Trigger the assertions inside dummy_app
+    dummy_app(environ, lambda *args: None)
+
+
+@pytest.mark.asyncio
+async def test_build_environ_server_unix_socket():
+    """
+    Ensure build_environ handles ASGI Unix socket format: [path, None].
+    SERVER_NAME gets the socket path; SERVER_PORT gets '0' (common convention).
+    """
+    def dummy_app(environ, start_response):
+        assert environ["SERVER_NAME"] == "/run/myapp.sock"
+        assert environ["SERVER_PORT"] == "0"
+        start_response("200 OK", [])
+        return [b"OK"]
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "server": ["/run/myapp.sock", None],
+        "headers": [],
+    }
+
+    instance = WsgiToAsgiInstance(dummy_app)
+    environ = instance.build_environ(scope, b"")
+    dummy_app(environ, lambda *args: None)
+
+
+@pytest.mark.asyncio
+async def test_build_environ_server_tcp():
+    """
+    Ensure normal TCP server tuple is handled unchanged.
+    """
+    def dummy_app(environ, start_response):
+        assert environ["SERVER_NAME"] == "example.com"
+        assert environ["SERVER_PORT"] == "8443"
+        start_response("200 OK", [])
+        return [b"OK"]
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "server": ["example.com", 8443],
+        "headers": [],
+    }
+
+    instance = WsgiToAsgiInstance(dummy_app)
+    environ = instance.build_environ(scope, b"")
+    dummy_app(environ, lambda *args: None)
+
+@pytest.mark.asyncio
+async def test_build_environ_server_missing():
+    """
+    Ensure missing 'server' key falls back to localhost:80.
+    """
+    def dummy_app(environ, start_response):
+        assert environ["SERVER_NAME"] == "localhost"
+        assert environ["SERVER_PORT"] == "80"
+        start_response("200 OK", [])
+        return [b"OK"]
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        # No "server" key at all
+        "headers": [],
+    }
+
+    instance = WsgiToAsgiInstance(dummy_app)
+    environ = instance.build_environ(scope, b"")
+    dummy_app(environ, lambda *args: None)
+
+
+@pytest.mark.asyncio
 async def test_wsgi_path_encoding():
     """
     Makes sure the WSGI wrapper has basic functionality.

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -394,7 +394,7 @@ def test_build_environ_server_present_but_none():
         "path": "/",
         "query_string": b"",
         "headers": [],
-        "server": None,  # <-- the buggy case
+        "server": None,
     }
     adapter = WsgiToAsgiInstance(None)
     adapter.scope = scope


### PR DESCRIPTION
Fixes #514

Some ASGI servers (e.g. Uvicorn with `--uds` / Unix sockets) include `"server": None` in the scope. The current `if "server" in scope` check then attempts to index `None`, raising `TypeError: 'NoneType' object is not subscriptable`.

This PR:
- Changes the check to `server = scope.get("server"); if server is not None:` 
- Sets `SERVER_PORT` to `"0"` when the port is `None` (standard for Unix socket cases)
- Adds new tests in `tests/test_wsgi.py`:

Matches the maintainer's suggestion from @carltongibson for `if scope.get("server") is not None`.