### PR TITLE
Handle stopped main event loops in async_to_sync

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -278,19 +278,21 @@ class AsyncToSync(Generic[_P, _R]):
                 finally:
                     del self.loop_thread_executors[loop]
 
-            if self.main_event_loop is not None:
+            running_in_main_event_loop = False
+            if (
+                self.main_event_loop is not None
+                and self.main_event_loop.is_running()
+            ):
                 try:
                     self.main_event_loop.call_soon_threadsafe(
                         self.main_event_loop.create_task, awaitable
                     )
                 except RuntimeError:
-                    running_in_main_event_loop = False
+                    pass
                 else:
                     running_in_main_event_loop = True
                     # Run the CurrentThreadExecutor until the future is done.
                     current_executor.run_until_future(call_result)
-            else:
-                running_in_main_event_loop = False
 
             if not running_in_main_event_loop:
                 loop_executor = None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,6 +2,7 @@ import asyncio
 import contextvars
 import functools
 import multiprocessing
+import os
 import sys
 import threading
 import time
@@ -15,6 +16,7 @@ import pytest
 
 from asgiref.sync import (
     AsyncSingleThreadContext,
+    SyncToAsync,
     ThreadSensitiveContext,
     async_to_sync,
     iscoroutinefunction,
@@ -398,6 +400,39 @@ def test_async_to_sync_in_thread():
     thread.start()
     thread.join()
     assert result["worked"]
+
+
+def test_async_to_sync_with_stopped_main_event_loop():
+    """
+    Tests async_to_sync falls back to a new loop if the threadlocal main event
+    loop has stopped but not yet closed.
+    """
+
+    async def inner_async_function():
+        return 84
+
+    stopped_loop = asyncio.new_event_loop()
+    result = {}
+    exception = {}
+
+    def thread_target():
+        SyncToAsync.threadlocal.main_event_loop = stopped_loop
+        SyncToAsync.threadlocal.main_event_loop_pid = os.getpid()
+        try:
+            result["value"] = async_to_sync(inner_async_function)()
+        except BaseException as exc:
+            exception["value"] = exc
+
+    thread = threading.Thread(target=thread_target, daemon=True)
+    thread.start()
+    thread.join(2)
+
+    try:
+        assert not thread.is_alive()
+        assert exception == {}
+        assert result["value"] == 84
+    finally:
+        stopped_loop.close()
 
 
 def test_async_to_sync_in_except():


### PR DESCRIPTION
## Summary

- only reuse the threadlocal `main_event_loop` when it is still running
- fall back to a new loop if that threadlocal loop has stopped but not closed
- add a regression test covering the stopped-but-open loop case

A stopped loop can still accept `call_soon_threadsafe()` without ever running the scheduled task, which leaves `async_to_sync()` blocked waiting for a result.

Fixes #545.

## Testing

- `python -m pytest -q`
- `python -m mypy asgiref tests setup.py docs/conf.py`