### PR TITLE
Add opt-in cancel_futures_on_exit to ThreadSensitiveContext

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,15 @@
+Unreleased
+----------
+
+* Added an opt-in ``cancel_futures_on_exit`` flag to ``ThreadSensitiveContext``.
+  When enabled, ``__aexit__`` calls ``executor.shutdown(wait=False,
+  cancel_futures=True)`` instead of waiting for worker threads to drain — an
+  escape hatch for the cross-call deadlock that occurs when sync code in the
+  context calls back into the event loop via ``SyncToAsync``. The default is
+  unchanged. The flag can be set per-instance, per-subclass, or process-wide
+  via the ``ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT`` environment
+  variable.
+
 3.11.1 (2026-02-03)
 -------------------
 

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -126,10 +126,31 @@ class ThreadSensitiveContext:
     >>> import time
     >>> async with ThreadSensitiveContext():
     ...     await sync_to_async(time.sleep, 1)()
+
+    ``__aexit__`` waits for every worker in the context's ``ThreadPoolExecutor``
+    to finish before returning. That is the safe default, but it deadlocks
+    when sync code inside the context calls back into the event loop via
+    ``SyncToAsync`` and the loop ends up cleaning the context while those
+    workers are still parked on a future the loop itself must produce
+    (see issues #545, #495, #458).
+
+    Set ``cancel_futures_on_exit`` (per-instance, per-subclass, or globally
+    via ``ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT=1``) to switch
+    ``executor.shutdown()`` to ``shutdown(wait=False, cancel_futures=True)`` —
+    pending futures are cancelled, the event loop is freed, and running
+    workers finish in the background. Trade graceful drain for liveness.
     """
 
-    def __init__(self):
+    #: Opt-in: skip the graceful drain on exit. Default preserves historic behaviour.
+    cancel_futures_on_exit: bool = (
+        os.environ.get("ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", "").lower()
+        in ("1", "true", "yes")
+    )
+
+    def __init__(self, cancel_futures_on_exit: bool | None = None):
         self.token = None
+        if cancel_futures_on_exit is not None:
+            self.cancel_futures_on_exit = cancel_futures_on_exit
 
     async def __aenter__(self):
         try:
@@ -145,7 +166,10 @@ class ThreadSensitiveContext:
 
         executor = SyncToAsync.context_to_thread_executor.pop(self, None)
         if executor:
-            executor.shutdown()
+            if self.cancel_futures_on_exit:
+                executor.shutdown(wait=False, cancel_futures=True)
+            else:
+                executor.shutdown()
         SyncToAsync.thread_sensitive_context.reset(self.token)
 
 

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -142,10 +142,9 @@ class ThreadSensitiveContext:
     """
 
     #: Opt-in: skip the graceful drain on exit. Default preserves historic behaviour.
-    cancel_futures_on_exit: bool = (
-        os.environ.get("ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", "").lower()
-        in ("1", "true", "yes")
-    )
+    cancel_futures_on_exit: bool = os.environ.get(
+        "ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", ""
+    ).lower() in ("1", "true", "yes")
 
     def __init__(self, cancel_futures_on_exit: bool | None = None):
         self.token = None

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -108,6 +108,17 @@ class AsyncSingleThreadContext:
         AsyncToSync.async_single_thread_context.reset(self.token)
 
 
+def _cancel_futures_on_exit_default_from_env() -> bool:
+    """Read ``ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT`` from the environment.
+
+    Split out so tests can exercise the parsing without importing in a
+    subprocess.
+    """
+    return os.environ.get(
+        "ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", ""
+    ).lower() in ("1", "true", "yes")
+
+
 class ThreadSensitiveContext:
     """Async context manager to manage context for thread sensitive mode
 
@@ -139,14 +150,16 @@ class ThreadSensitiveContext:
     ``executor.shutdown()`` to ``shutdown(wait=False, cancel_futures=True)`` —
     pending futures are cancelled, the event loop is freed, and running
     workers finish in the background. Trade graceful drain for liveness.
+
+    The environment variable is read once when the class is defined, so it
+    must be set before ``asgiref.sync`` is imported. Use the constructor
+    argument or a subclass attribute to change the value at runtime.
     """
 
     #: Opt-in: skip the graceful drain on exit. Default preserves historic behaviour.
-    cancel_futures_on_exit: bool = os.environ.get(
-        "ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", ""
-    ).lower() in ("1", "true", "yes")
+    cancel_futures_on_exit: bool = _cancel_futures_on_exit_default_from_env()
 
-    def __init__(self, cancel_futures_on_exit: bool | None = None):
+    def __init__(self, cancel_futures_on_exit: Optional[bool] = None):
         self.token = None
         if cancel_futures_on_exit is not None:
             self.cancel_futures_on_exit = cancel_futures_on_exit

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -732,29 +732,44 @@ async def test_thread_sensitive_context_cancel_futures_on_exit_per_instance():
     ]
 
 
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("True", True),
+        ("YES", True),
+        ("0", False),
+        ("false", False),
+        ("", False),
+        ("anything-else", False),
+    ],
+)
+def test_cancel_futures_on_exit_default_from_env(monkeypatch, value, expected):
+    """Parsing of ``ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT``."""
+    from asgiref.sync import _cancel_futures_on_exit_default_from_env
+
+    monkeypatch.setenv("ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", value)
+    assert _cancel_futures_on_exit_default_from_env() is expected
+
+
 @pytest.mark.asyncio
-async def test_thread_sensitive_context_cancel_futures_on_exit_via_env(monkeypatch):
-    """Global opt-in via ``ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT``."""
-    monkeypatch.setenv("ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", "1")
-
-    # Re-evaluate the class default by reimporting; in-process we mimic that
-    # by setting the class attribute, which is what the env var feeds into.
-    monkeypatch.setattr(ThreadSensitiveContext, "cancel_futures_on_exit", True)
-
+async def test_thread_sensitive_context_explicit_false_overrides_class_attribute():
+    """Instance argument ``cancel_futures_on_exit=False`` wins over a True class attribute."""
     shutdown_calls = []
 
     class _Recorder:
         def shutdown(self, *args, **kwargs):
             shutdown_calls.append({"args": args, "kwargs": kwargs})
 
-    ctx = ThreadSensitiveContext()
-    assert ctx.cancel_futures_on_exit is True
+    class _OptedIn(ThreadSensitiveContext):
+        cancel_futures_on_exit = True
+
+    ctx = _OptedIn(cancel_futures_on_exit=False)
     async with ctx:
         SyncToAsync.context_to_thread_executor[ctx] = _Recorder()
 
-    assert shutdown_calls == [
-        {"args": (), "kwargs": {"wait": False, "cancel_futures": True}}
-    ]
+    assert shutdown_calls == [{"args": (), "kwargs": {}}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -15,6 +15,7 @@ import pytest
 
 from asgiref.sync import (
     AsyncSingleThreadContext,
+    SyncToAsync,
     ThreadSensitiveContext,
     async_to_sync,
     iscoroutinefunction,
@@ -688,6 +689,93 @@ async def test_thread_sensitive_nested_context():
 async def test_thread_sensitive_context_without_sync_work():
     async with ThreadSensitiveContext():
         pass
+
+
+@pytest.mark.asyncio
+async def test_thread_sensitive_context_default_drains_executor_gracefully(monkeypatch):
+    """Default behaviour: ``executor.shutdown()`` called without ``cancel_futures``."""
+    monkeypatch.delenv("ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", raising=False)
+
+    shutdown_calls = []
+
+    class _Recorder:
+        def shutdown(self, *args, **kwargs):
+            shutdown_calls.append({"args": args, "kwargs": kwargs})
+
+    ctx = ThreadSensitiveContext()
+    assert ctx.cancel_futures_on_exit is False, (
+        "default must preserve historic graceful drain behaviour"
+    )
+    async with ctx:
+        SyncToAsync.context_to_thread_executor[ctx] = _Recorder()
+
+    assert shutdown_calls == [{"args": (), "kwargs": {}}], (
+        "default shutdown must remain wait=True with no cancel_futures"
+    )
+
+
+@pytest.mark.asyncio
+async def test_thread_sensitive_context_cancel_futures_on_exit_per_instance():
+    """Per-instance opt-in cancels pending futures and skips the join."""
+    shutdown_calls = []
+
+    class _Recorder:
+        def shutdown(self, *args, **kwargs):
+            shutdown_calls.append({"args": args, "kwargs": kwargs})
+
+    ctx = ThreadSensitiveContext(cancel_futures_on_exit=True)
+    async with ctx:
+        SyncToAsync.context_to_thread_executor[ctx] = _Recorder()
+
+    assert shutdown_calls == [
+        {"args": (), "kwargs": {"wait": False, "cancel_futures": True}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_thread_sensitive_context_cancel_futures_on_exit_via_env(monkeypatch):
+    """Global opt-in via ``ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT``."""
+    monkeypatch.setenv("ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT", "1")
+
+    # Re-evaluate the class default by reimporting; in-process we mimic that
+    # by setting the class attribute, which is what the env var feeds into.
+    monkeypatch.setattr(ThreadSensitiveContext, "cancel_futures_on_exit", True)
+
+    shutdown_calls = []
+
+    class _Recorder:
+        def shutdown(self, *args, **kwargs):
+            shutdown_calls.append({"args": args, "kwargs": kwargs})
+
+    ctx = ThreadSensitiveContext()
+    assert ctx.cancel_futures_on_exit is True
+    async with ctx:
+        SyncToAsync.context_to_thread_executor[ctx] = _Recorder()
+
+    assert shutdown_calls == [
+        {"args": (), "kwargs": {"wait": False, "cancel_futures": True}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_thread_sensitive_context_cancel_futures_on_exit_via_subclass():
+    """Subclass opt-in: override ``cancel_futures_on_exit`` on a subclass."""
+    shutdown_calls = []
+
+    class _Recorder:
+        def shutdown(self, *args, **kwargs):
+            shutdown_calls.append({"args": args, "kwargs": kwargs})
+
+    class _NoDrain(ThreadSensitiveContext):
+        cancel_futures_on_exit = True
+
+    ctx = _NoDrain()
+    async with ctx:
+        SyncToAsync.context_to_thread_executor[ctx] = _Recorder()
+
+    assert shutdown_calls == [
+        {"args": (), "kwargs": {"wait": False, "cancel_futures": True}}
+    ]
 
 
 def test_thread_sensitive_double_nested_sync():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -703,15 +703,15 @@ async def test_thread_sensitive_context_default_drains_executor_gracefully(monke
             shutdown_calls.append({"args": args, "kwargs": kwargs})
 
     ctx = ThreadSensitiveContext()
-    assert ctx.cancel_futures_on_exit is False, (
-        "default must preserve historic graceful drain behaviour"
-    )
+    assert (
+        ctx.cancel_futures_on_exit is False
+    ), "default must preserve historic graceful drain behaviour"
     async with ctx:
         SyncToAsync.context_to_thread_executor[ctx] = _Recorder()
 
-    assert shutdown_calls == [{"args": (), "kwargs": {}}], (
-        "default shutdown must remain wait=True with no cancel_futures"
-    )
+    assert shutdown_calls == [
+        {"args": (), "kwargs": {}}
+    ], "default shutdown must remain wait=True with no cancel_futures"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`ThreadSensitiveContext.__aexit__` calls `executor.shutdown()` with the implicit `wait=True`. When sync middleware inside the context invokes `SyncToAsync` to call back into the event loop, the request-scoped pool ends up waiting on a future the loop itself must produce:

- the main loop blocks on `executor.shutdown()`, waiting for worker threads to drain
- the worker threads block on `current_thread_executor.run_until_future`, waiting on a future the loop must run

Neither side can make progress. This is the failure mode reported in #545, #495, and #458.

## Proposal

Add an opt-in `cancel_futures_on_exit` flag that switches the shutdown call to `executor.shutdown(wait=False, cancel_futures=True)`. The default is unchanged.

Three ways to opt in:

- constructor argument
  ```python
  async with ThreadSensitiveContext(cancel_futures_on_exit=True):
      ...
  ```
- subclass attribute (useful when the context is instantiated by framework code you cannot easily reach)
  ```python
  class MyTSCtx(ThreadSensitiveContext):
      cancel_futures_on_exit = True
  ```
- environment variable for process-wide opt-in
  ```
  ASGIREF_CANCEL_FUTURES_ON_THREADSENSITIVE_EXIT=1
  ```

## Trade-off

With the flag on, pending futures are cancelled and `shutdown` returns immediately. Running worker threads cannot be interrupted mid-syscall in Python, so they finish in the background; their results are discarded because the context is already gone, and any resources they own are released on thread exit. Graceful drain is traded for liveness.

## Tests

`tests/test_sync.py` covers the historic default plus each of the three opt-in surfaces. The rest of the suite is unaffected.

## Production observation

In our deployment (Django ASGI + Daphne + ninja API, sync middleware chain underneath an async view) this deadlock manifests as the pod becoming unresponsive — no `/internal/health` response, no API requests served. Kubernetes' liveness probe eventually SIGKILLs the container, so there is no permanent outage, but every cycle costs the configured failure threshold (5 minutes in our setup) of full service unavailability. Over an 8‑day window we observed 19/19 pod restarts following this exact pattern, on average every 5.4 hours.

After applying the same change as a monkey-patch in our service, the cycle stopped under identical load. Filing this PR so users in similar situations have an upstream-blessed way out instead of patching `asgiref` in place.

## References

- #545 Nested AsyncToSync and SyncToAsync results in blocking code
- #495 sync_to_async detects deadlock in case of issue in loop.run_in_executor
- #458 ThreadPoolExecutor accumulation in SyncToAsync
