### PR TITLE
Use asyncio.run in StatelessServer.run

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,10 @@ UNRELEASED
 
 * Dropped support for EOL Python 3.9.
 
+* Fixed ``StatelessServer.run()`` failing on Python 3.14, where
+  ``asyncio.get_event_loop()`` no longer creates an event loop if none
+  exists. It now uses ``asyncio.run()``. (#559)
+
 3.11.1 (2026-02-03)
 -------------------
 

--- a/asgiref/server.py
+++ b/asgiref/server.py
@@ -56,9 +56,8 @@ class StatelessServer:
         """
         Runs the asyncio event loop with our handler loop.
         """
-        event_loop = asyncio.get_event_loop()
         try:
-            event_loop.run_until_complete(self.arun())
+            asyncio.run(self.arun())
         except KeyboardInterrupt:
             logger.info("Exiting due to Ctrl-C/interrupt")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import socket as sock
+import threading
 
 import pytest
 import pytest_asyncio
@@ -124,14 +125,19 @@ async def test_stateless_server(server):
         pass
 
 
-def test_run_creates_event_loop_when_none_exists(monkeypatch):
+def test_stateless_server_run():
+    """
+    StatelessServer.run() manages its own event loop.
+
+    Run in a fresh thread, which never has a current event loop — the same
+    situation as the main thread on Python 3.14+.
+    """
+
     async def app(scope, receive, send):
         pass
 
     class RunServer(StatelessServer):
-        def __init__(self):
-            super().__init__(app)
-            self.handled = False
+        handled = False
 
         async def handle(self):
             self.handled = True
@@ -139,14 +145,22 @@ def test_run_creates_event_loop_when_none_exists(monkeypatch):
         async def application_send(self, scope, message):
             pass
 
-    def raise_no_event_loop():
-        raise RuntimeError("There is no current event loop in thread 'MainThread'.")
+    server = RunServer(app)
+    errors = []
 
-    monkeypatch.setattr(asyncio, "get_event_loop", raise_no_event_loop)
+    def run():
+        try:
+            server.run()
+        except BaseException as exc:
+            errors.append(exc)
 
-    server = RunServer()
-    server.run()
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join(timeout=5)
 
+    assert not thread.is_alive()
+    if errors:
+        raise errors[0]
     assert server.handled
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -124,6 +124,32 @@ async def test_stateless_server(server):
         pass
 
 
+def test_run_creates_event_loop_when_none_exists(monkeypatch):
+    async def app(scope, receive, send):
+        pass
+
+    class RunServer(StatelessServer):
+        def __init__(self):
+            super().__init__(app)
+            self.handled = False
+
+        async def handle(self):
+            self.handled = True
+
+        async def application_send(self, scope, message):
+            pass
+
+    def raise_no_event_loop():
+        raise RuntimeError("There is no current event loop in thread 'MainThread'.")
+
+    monkeypatch.setattr(asyncio, "get_event_loop", raise_no_event_loop)
+
+    server = RunServer()
+    server.run()
+
+    assert server.handled
+
+
 @pytest.mark.asyncio
 async def test_server_delete_instance(server):
     """The max_applications of Server is 10. After 20 times register, application number should be 10."""


### PR DESCRIPTION
`StatelessServer.run()` currently calls `asyncio.get_event_loop()` before running `arun()`. On Python 3.14, a fresh main thread may not have a current event loop, so this raises before the server can start.

This switches the synchronous entry point to `asyncio.run(self.arun())`, which creates and manages the loop for this one-shot runner. I also added a regression test that patches `asyncio.get_event_loop()` to raise with the Python 3.14-style failure and confirms `run()` still reaches the handler.

Refs #559.

Tests:

- `.venv\Scripts\python -m pytest tests\test_server.py::test_run_creates_event_loop_when_none_exists -q`
- `.venv\Scripts\python -m pytest tests\test_server.py -q`
- `.venv\Scripts\python -m pytest -q`
- `.venv\Scripts\python -m mypy .`
- `git diff --check`