### PR TITLE
 Don’t capture the event loop in `AsyncToSync.__init__`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,9 +1,33 @@
 UNRELEASED
 ----------
 
-* Fixed a deadlock of the entire event loop when exiting
-  ``ThreadSensitiveContext`` while its executor thread was still blocked
-  waiting on the event loop. (#535)
+* ``AsyncToSync`` no longer captures the running event loop on
+  instantiation. (#562)
+
+  This resolves a series of deadlocks that users experienced after asgiref 3.9.0,
+  particularly with pytest-asyncio. pytest-asyncio stops the event loop between
+  tests, and long-running unawaited futures could find themselves trying to
+  schedule work onto a stopped loop, and so would never complete. Ideally, code
+  should be structured to await long-running futures before returning, but this
+  change should help users experiencing issues here.
+
+  The loop is now resolved when the callable is invoked rather than when it is
+  created. If ``async_to_sync`` is called from within ``sync_to_async``, the
+  parent event loop is still used, as before.
+
+  The possibility of deadlock therefore remains in some nested patterns. For
+  example, an async function may call a long-running ``sync_to_async`` function
+  that itself uses ``async_to_sync``; if the outer function returns before the
+  sync future completes, the parent event loop may already be stopped, and the
+  nested calls cannot be driven to completion.
+
+  This is not a bug in asgiref — the same patterns deadlock in plain asyncio. As
+  above, restructure your code to await the ``sync_to_async`` future before
+  exiting the driving coroutine.
+
+* Fixed an event loop deadlock when exiting ``ThreadSensitiveContext``
+  while its executor thread was still blocked waiting on the event loop.
+  (#535)
 
 * Dropped support for EOL Python 3.9.
 

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -207,17 +207,12 @@ class AsyncToSync(Generic[_P, _R]):
         except AttributeError:
             pass
         self.force_new_loop = force_new_loop
-        self.main_event_loop = None
-        try:
-            self.main_event_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # There's no event loop in this thread.
-            pass
 
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         __traceback_hide__ = True  # noqa: F841
 
-        if not self.force_new_loop and not self.main_event_loop:
+        main_event_loop = None
+        if not self.force_new_loop:
             # There's no event loop in this thread. Look for the threadlocal if
             # we're inside SyncToAsync
             main_event_loop_pid = getattr(
@@ -226,7 +221,7 @@ class AsyncToSync(Generic[_P, _R]):
             # We make sure the parent loop is from the same process - if
             # they've forked, this is not going to be valid any more (#194)
             if main_event_loop_pid and main_event_loop_pid == os.getpid():
-                self.main_event_loop = getattr(
+                main_event_loop = getattr(
                     SyncToAsync.threadlocal, "main_event_loop", None
                 )
 
@@ -284,10 +279,10 @@ class AsyncToSync(Generic[_P, _R]):
                 finally:
                     del self.loop_thread_executors[loop]
 
-            if self.main_event_loop is not None:
+            if main_event_loop is not None:
                 try:
-                    self.main_event_loop.call_soon_threadsafe(
-                        self.main_event_loop.create_task, awaitable
+                    main_event_loop.call_soon_threadsafe(
+                        main_event_loop.create_task, awaitable
                     )
                 except RuntimeError:
                     running_in_main_event_loop = False

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -277,8 +277,6 @@ async def test_async_to_sync_to_thread_decorator():
     number = await asyncio.to_thread(inner_async_function)
     assert number == 42
     assert result["worked"]
-    # Make sure that it didn't needlessly make a new async loop
-    assert result["thread"] == threading.current_thread()
 
 
 def test_async_to_sync_fail_non_function():

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1504,3 +1504,37 @@ if sys.version_info >= (3, 11):
             await task1
 
         asyncio.run(main())
+
+
+def test_async_to_sync_with_stopped_main_loop():
+    """
+    A wrapper built while a loop is running captures that loop. If the loop is
+    later stopped but not closed (e.g. a shared pytest-asyncio loop between
+    tests), calling the wrapper from a sync thread must fall back to a new loop
+    rather than deadlock.
+    """
+    holder = {}
+
+    async def inner():
+        return 42
+
+    async def build():
+        holder["fn"] = async_to_sync(inner)
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(build())
+        assert not loop.is_running() and not loop.is_closed()
+
+        result = {}
+
+        def worker():
+            result["value"] = holder["fn"]()
+
+        thread = threading.Thread(target=worker, daemon=True)
+        thread.start()
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "async_to_sync deadlocked on a stopped loop"
+        assert result["value"] == 42
+    finally:
+        loop.close()


### PR DESCRIPTION
It was unintuitive that merely defining a function in a different location should affect which loop it uses when called.

`test_async_to_sync_to_thread_decorator` was the only test in the whole test suite where a captured loop made it through the top of `AsyncToSync.__call__` without being replaced. This test was wrong to expect us to capture the loop across `asyncio.to_thread`:

`asyncio.to_thread` intentionally doesn’t copy the running loop to the new thread, because a loop object is not thread-safe. Granted, we only use the thread-safe subset of the loop interface. However, the user shouldn’t expect that. If they wanted to go back to the old thread, they would have written `sync_to_async` instead of `asyncio.to_thread`.

Includes the test case from https://github.com/django/asgiref/pull/558#issuecomment-4515994185, which now passes.