### PR TITLE
Test free-threading builds and fix Local data leak for thread_inherit_context

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-        - '3.10'
-        - '3.11'
-        - '3.12'
-        - '3.13'
-        - '3.14'
+        include:
+        - { python-version: '3.10',  toxenv: 'py310-test,py310-mypy' }
+        - { python-version: '3.11',  toxenv: 'py311-test,py311-mypy' }
+        - { python-version: '3.12',  toxenv: 'py312-test,py312-mypy' }
+        - { python-version: '3.13',  toxenv: 'py313-test,py313-mypy' }
+        - { python-version: '3.14',  toxenv: 'py314-test,py314-mypy' }
+        - { python-version: '3.13t', toxenv: 'py313t-test' }
+        - { python-version: '3.14t', toxenv: 'py314t-test' }
 
     steps:
       - uses: actions/checkout@v5
@@ -32,10 +34,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox tox-py
+          python -m pip install --upgrade tox
 
-      - name: Run tox targets for ${{ matrix.python-version }}
-        run: tox --py current
+      - name: Run tox env ${{ matrix.toxenv }}
+        run: tox -e ${{ matrix.toxenv }}
 
   lint:
     name: Lint

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,15 @@ UNRELEASED
   ``asyncio.get_event_loop()`` no longer creates an event loop if none
   exists. It now uses ``asyncio.run()``. (#559)
 
+* Fixed ``Local`` leaking data between unrelated sync threads when
+  ``sys.flags.thread_inherit_context`` is enabled (Python 3.14+), so a newly
+  started thread inherits a copy of the spawning thread's context. This flag is
+  on by default on free-threaded builds and opt-in on the regular GIL build.
+  ``Local`` storage is now tagged with its owning thread and re-homed only when
+  asgiref intentionally moves work across threads (in ``async_to_sync`` /
+  ``sync_to_async``), restoring the documented thread-local behaviour in sync
+  threads.
+
 3.11.1 (2026-02-03)
 -------------------
 

--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -2,21 +2,58 @@ import asyncio
 import contextlib
 import contextvars
 import threading
-from typing import Any, Dict, Union
+from typing import Any, Union
+
+
+class _Storage:
+    """Thread-tagged storage for a non-thread-critical ``Local``.
+
+    The data is tagged with the identity of the thread that owns it. This lets
+    ``_CVar`` ignore data that leaked into an unrelated thread.
+
+    Python 3.14 added ``sys.flags.thread_inherit_context``, which is enabled by
+    default on free-threaded builds. When set, a new thread starts with a copy
+    of the spawning thread's context instead of an empty one, so the contextvar
+    backing a ``Local`` would otherwise be visible in any thread spawned from
+    one that had set it -- breaking the documented "thread-local in sync
+    threads" behaviour. asgiref re-homes the storage to the current thread at
+    the points where it *intentionally* moves work between threads (see
+    ``asgiref.sync._restore_context``); data merely inherited by an unrelated
+    thread is never re-homed and so stays isolated.
+    """
+
+    __slots__ = ("thread_id", "data")
+
+    def __init__(self, thread_id: int, data: dict[str, Any]) -> None:
+        self.thread_id = thread_id
+        self.data = data
+
+
+def _rehome(storage: "_Storage") -> "_Storage":
+    """Return a copy of *storage* owned by the current thread."""
+    return _Storage(threading.get_ident(), storage.data)
 
 
 class _CVar:
     """Storage utility for Local."""
 
     def __init__(self) -> None:
-        self._data: "contextvars.ContextVar[Dict[str, Any]]" = contextvars.ContextVar(
+        self._data: "contextvars.ContextVar[_Storage]" = contextvars.ContextVar(
             "asgiref.local"
         )
 
+    def _storage(self) -> "_Storage":
+        # Only return storage that belongs to the current thread. Storage with
+        # a different thread id was inherited by this thread (rather than
+        # intentionally moved here by asgiref) and must not be visible.
+        storage = self._data.get(None)
+        if storage is None or storage.thread_id != threading.get_ident():
+            return _Storage(threading.get_ident(), {})
+        return storage
+
     def __getattr__(self, key):
-        storage_object = self._data.get({})
         try:
-            return storage_object[key]
+            return self._storage().data[key]
         except KeyError:
             raise AttributeError(f"{self!r} object has no attribute {key!r}")
 
@@ -24,15 +61,15 @@ class _CVar:
         if key == "_data":
             return super().__setattr__(key, value)
 
-        storage_object = self._data.get({}).copy()
-        storage_object[key] = value
-        self._data.set(storage_object)
+        data = self._storage().data.copy()
+        data[key] = value
+        self._data.set(_Storage(threading.get_ident(), data))
 
     def __delattr__(self, key: str) -> None:
-        storage_object = self._data.get({}).copy()
-        if key in storage_object:
-            del storage_object[key]
-            self._data.set(storage_object)
+        data = self._storage().data.copy()
+        if key in data:
+            del data[key]
+            self._data.set(_Storage(threading.get_ident(), data))
         else:
             raise AttributeError(f"{self!r} object has no attribute {key!r}")
 

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 from .current_thread_executor import CurrentThreadExecutor
-from .local import Local
+from .local import Local, _rehome, _Storage
 
 if TYPE_CHECKING:
     # This is not available to import at runtime
@@ -39,6 +39,12 @@ def _restore_context(context: contextvars.Context) -> None:
     # context for downstream consumers
     for cvar in context:
         cvalue = context.get(cvar)
+        # asgiref is deliberately moving this context onto the current thread,
+        # so re-home any Local storage to it. This keeps Local data visible
+        # across async_to_sync / sync_to_async boundaries while leaving data
+        # merely inherited by an unrelated thread isolated (see asgiref.local).
+        if isinstance(cvalue, _Storage):
+            cvalue = _rehome(cvalue)
         try:
             if cvar.get() != cvalue:
                 cvar.set(cvalue)
@@ -486,7 +492,15 @@ class SyncToAsync(Generic[_P, _R]):
             executor = self._executor
 
         context = contextvars.copy_context() if self.context is None else self.context
-        child = functools.partial(self.func, *args, **kwargs)
+        inner = functools.partial(self.func, *args, **kwargs)
+
+        def child() -> _R:
+            # The sync function runs inside ``context`` (a copy of the calling
+            # async context) on a worker thread. Re-home any Local storage to
+            # this thread so it stays visible here (see _restore_context).
+            _restore_context(context)
+            return inner()
+
         func = context.run
         task_context: list[asyncio.Task[Any]] = []
 

--- a/tests/test_garbage_collection.py
+++ b/tests/test_garbage_collection.py
@@ -35,6 +35,14 @@ def clean_up_after_garbage_collection_test() -> None:
 @pytest.mark.skipif(
     sys.implementation.name == "pypy", reason="Test relies on CPython GC internals"
 )
+@pytest.mark.skipif(
+    not getattr(sys, "_is_gil_enabled", lambda: True)(),
+    reason=(
+        "On a free-threaded build the cyclic collector may reclaim objects that "
+        "are freed immediately by reference counting under the GIL, so they show "
+        "up in gc.garbage with DEBUG_SAVEALL even without a real leak."
+    ),
+)
 def test_thread_critical_Local_remove_all_reference_cycles() -> None:
     try:
         # given

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import gc
 import threading
 from threading import Thread
@@ -357,6 +358,45 @@ def test_visibility_thread_asgiref() -> None:
     thread.join()
 
     assert test_local.value == 0
+
+
+def test_local_not_inherited_by_new_thread() -> None:
+    """
+    A value set in one sync thread must not be visible in a separately spawned
+    sync thread.
+
+    On Python 3.14+ a new thread inherits a copy of the spawning thread's
+    context when ``sys.flags.thread_inherit_context`` is enabled. That flag
+    defaults to on for free-threaded builds and off for the regular GIL build
+    (where it is opt-in via ``-X thread_inherit_context=1`` /
+    ``PYTHON_THREAD_INHERIT_CONTEXT=1``). When enabled it would otherwise leak
+    non-thread-critical ``Local`` data across unrelated threads.
+    """
+    test_local = Local()
+    test_local.value = "parent"
+
+    # Capture the child's observation in the parent so an in-thread assertion
+    # failure actually fails the test.
+    observed: "dict[str, object]" = {}
+
+    def child() -> None:
+        observed["has_value"] = hasattr(test_local, "value")
+        # The child gets its own isolated storage.
+        test_local.value = "child"
+        observed["child_value"] = test_local.value
+
+    # Force the worst case by running the child in a copy of this thread's
+    # context (mirroring thread_inherit_context), so the test exercises the leak
+    # path on every build regardless of the flag default.
+    parent_context = contextvars.copy_context()
+    thread = Thread(target=lambda: parent_context.run(child))
+    thread.start()
+    thread.join()
+
+    assert observed["has_value"] is False
+    assert observed["child_value"] == "child"
+    # The child's write must not leak back to the parent either.
+    assert test_local.value == "parent"
 
 
 @pytest.mark.asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{310,311,312,313,314}-{test,mypy}
+    py{313,314}t-test
     qa
 
 [testenv]
@@ -11,6 +12,14 @@ commands =
     mypy: mypy . {posargs}
 deps =
     setuptools
+
+# Free-threaded (GIL-disabled) builds. basepython is set explicitly so the env
+# resolves to the free-threaded interpreter regardless of tox version.
+[testenv:py313t-test]
+basepython = python3.13t
+
+[testenv:py314t-test]
+basepython = python3.14t
 
 [testenv:qa]
 skip_install = true


### PR DESCRIPTION
Running Django's test suite against free-threading builds revealed a leak in Local when `sys.flags.thread_inherit_context` is enabled, which it is by default for the free-threading builds.

Fix that, and add test runs for free-threading builds.

See also https://github.com/django/django/pull/21521