### PR TITLE
Wrap async_to_sync with functools.update_wrapper

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+UNRELEASED
+----------
+
+* ``async_to_sync`` now copies the wrapped function's metadata (``__name__``,
+  ``__wrapped__``, etc.) onto the returned callable, matching ``sync_to_async``.
+  (#500)
+
 3.11.1 (2026-02-03)
 -------------------
 

--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -196,6 +196,7 @@ class AsyncToSync(Generic[_P, _R]):
                 "async_to_sync was passed a non-async-marked callable", stacklevel=2
             )
         self.awaitable = awaitable
+        functools.update_wrapper(self, awaitable)
         try:
             self.__self__ = self.awaitable.__self__  # type: ignore[union-attr]
         except AttributeError:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -159,6 +159,23 @@ async def test_nested_sync_to_async_retains_wrapped_function_attributes():
     assert test_function.__name__ == "test_function"
 
 
+def test_async_to_sync_retains_wrapped_function_attributes():
+    """
+    Tests that attributes of functions wrapped by async_to_sync are retained
+    """
+
+    async def test_function():
+        """Docstring."""
+
+    test_function.attr_name = "test_name_attribute"
+
+    wrapped = async_to_sync(test_function)
+    assert wrapped.__name__ == "test_function"
+    assert wrapped.__doc__ == "Docstring."
+    assert wrapped.__wrapped__ is test_function
+    assert wrapped.attr_name == "test_name_attribute"
+
+
 @pytest.mark.asyncio
 async def test_sync_to_async_method_decorator():
     """


### PR DESCRIPTION
Fixes #500.

`async_to_sync` doesn't copy the wrapped function's metadata onto the callable it returns, so attributes like `__name__` and `__wrapped__` are missing. People work around it by wrapping the result in `functools.wraps` themselves (the issue shows this).

`sync_to_async` already calls `functools.update_wrapper(self, func)` in its `__init__`, and `AsyncToSync.__get__` does the same when used as a method decorator. `AsyncToSync.__init__` was the only one that didn't, so this was just an inconsistency.

The fix is one line in `AsyncToSync.__init__`. I also added a test next to the existing `sync_to_async` attribute test. Without the fix the new test fails with `AttributeError: 'AsyncToSync' object has no attribute '__name__'`; with it the name, docstring, `__wrapped__` and custom attributes all carry over.