### PR TITLE
Reject generator functions in sync_to_async

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -426,10 +426,15 @@ class SyncToAsync(Generic[_P, _R]):
         executor: Optional["ThreadPoolExecutor"] = None,
         context: Optional[contextvars.Context] = None,
     ) -> None:
+        func_call = getattr(func, "__call__", func)
         if (
             not callable(func)
             or iscoroutinefunction(func)
-            or iscoroutinefunction(getattr(func, "__call__", func))
+            or iscoroutinefunction(func_call)
+            or inspect.isgeneratorfunction(func)
+            or inspect.isgeneratorfunction(func_call)
+            or inspect.isasyncgenfunction(func)
+            or inspect.isasyncgenfunction(func_call)
         ):
             raise TypeError("sync_to_async can only be applied to sync functions.")
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -74,6 +74,22 @@ def test_sync_to_async_fail_non_function():
     )
 
 
+def test_sync_to_async_fail_generator_function():
+    """
+    sync_to_async raises a TypeError when applied to a generator function.
+    """
+
+    def test_function():
+        yield 1
+
+    with pytest.raises(TypeError) as excinfo:
+        sync_to_async(test_function)
+
+    assert excinfo.value.args == (
+        "sync_to_async can only be applied to sync functions.",
+    )
+
+
 @pytest.mark.asyncio
 async def test_sync_to_async_fail_async():
     """
@@ -113,6 +129,17 @@ async def test_sync_to_async_raises_typeerror_for_async_callable_instance():
     class CallableClass:
         async def __call__(self):
             return None
+
+    with pytest.raises(
+        TypeError, match="sync_to_async can only be applied to sync functions."
+    ):
+        sync_to_async(CallableClass())
+
+
+def test_sync_to_async_raises_typeerror_for_generator_callable_instance():
+    class CallableClass:
+        def __call__(self):
+            yield 1
 
     with pytest.raises(
         TypeError, match="sync_to_async can only be applied to sync functions."


### PR DESCRIPTION
## Summary

- reject synchronous and asynchronous generator functions in `sync_to_async()` with the existing TypeError path
- apply the same detection to callable instances via their `__call__` method
- add regression tests for generator functions and generator callable instances

`sync_to_async()` currently calls a generator function in the worker thread only far enough to create the generator object. Iterating that generator then runs the body in the caller thread, which is the confusing behavior reported in the issue. Raising early is safer than returning an object that does not actually execute under the adapter.

Fixes #38

## Tests

- `python -m pytest tests\test_sync.py -q`
- `python -m pytest -q`
- `python -m mypy asgiref tests\test_sync.py`
- `git diff --check`