### PR TITLE
Use asyncio.timeout on Python 3.11+

### DIFF
--- a/asgiref/testing.py
+++ b/asgiref/testing.py
@@ -1,9 +1,14 @@
 import asyncio
 import contextvars
+import sys
 import time
 
 from .compatibility import guarantee_single_callable
-from .timeout import timeout as async_timeout
+
+if sys.version_info >= (3, 11):
+    async_timeout = asyncio.timeout
+else:
+    from .timeout import timeout as async_timeout
 
 
 class ApplicationCommunicator:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -48,6 +48,32 @@ async def test_receive_nothing():
     assert await instance.receive_nothing(0.01) is True
 
 
+@pytest.mark.asyncio
+async def test_receive_output_timeout_restores_cancellation_count():
+    """A handled timeout must not leave its task in a cancelling state."""
+    if not hasattr(asyncio, "timeout"):
+        pytest.skip("Task cancellation counts were added in Python 3.11")
+
+    async def application(scope, receive, send):
+        await asyncio.Event().wait()
+
+    instance = ApplicationCommunicator(application, {})
+    task = asyncio.current_task()
+    assert task is not None
+    cancelling = getattr(task, "cancelling")
+    uncancel = getattr(task, "uncancel")
+    before = cancelling()
+
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await instance.receive_output(timeout=0)
+
+        assert cancelling() == before
+    finally:
+        while cancelling() > before:
+            uncancel()
+
+
 def test_receive_nothing_lazy_loop():
     """
     Tests ApplicationCommunicator.receive_nothing to return the correct value.


### PR DESCRIPTION
## Summary

- use `asyncio.timeout` for `ApplicationCommunicator` on Python 3.11+
- keep the existing vendored timeout unchanged as the Python 3.10 fallback
- cover cancellation-count restoration after a handled `receive_output` timeout

Related to #504.

## Verification

The regression test failed before the production change because the handled timeout left the current task's cancellation count at `1` instead of restoring it to `0`.

- `pytest tests/test_testing.py -q`
- `pytest -q` — 98 passed, 1 xfailed on Python 3.12
- `mypy .`
- `pre-commit run --files asgiref/testing.py tests/test_testing.py`
- Python 3.10 container — 95 passed, 2 skipped, 1 xfailed; mypy passed
- Python 3.11 and 3.14 containers — focused tests passed
- Python 3.14 container — 98 passed, 1 xfailed; mypy passed
