### PR TITLE
Fix typo: stricly -> strictly in local.py docstring

### DIFF
--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -59,7 +59,7 @@ class Local:
     If `thread_critical` is True, then the local will only be visible per-thread,
     behaving exactly like `threading.local` if the thread is sync, and as
     `contextvars` if the thread is async. This allows genuinely thread-sensitive
-    code (such as DB handles) to be kept stricly to their initial thread and
+    code (such as DB handles) to be kept strictly to their initial thread and
     disable the sharing across `sync_to_async` and `async_to_sync` wrapped calls.
 
     Unlike plain `contextvars` objects, this utility is threadsafe.


### PR DESCRIPTION
Fix a small typo in the `Local` class docstring in `asgiref/local.py`:

- `stricly` → `strictly` (line 62)

Found by running [codespell](https://github.com/codespell-project/codespell) over the repo.