### PR TITLE
Update uvicorn's outdated link and starlette status

### DIFF
--- a/docs/implementations.rst
+++ b/docs/implementations.rst
@@ -64,7 +64,7 @@ Unit is a lightweight and versatile open-source server that has three core capab
 Uvicorn
 -------
 
-*Stable* / https://www.uvicorn.org/
+*Stable* / https://uvicorn.dev/
 
 A fast ASGI server based on uvloop and httptools.
 Supports HTTP/1 and WebSockets.
@@ -197,7 +197,7 @@ for type conversion. Optional OpenAPI document generation.
 Starlette
 ---------
 
-*Beta* / https://github.com/encode/starlette
+*Stable* / https://starlette.dev/
 
 Starlette is a minimalist ASGI library for writing against basic but powerful
 ``Request`` and ``Response`` classes. Supports HTTP and WebSockets.


### PR DESCRIPTION
I found that the Uvicorn link `https://www.uvicorn.org/` was broken, so I fixed it.
I also updated the Starlette GitHub repository link since it was outdated as well.
Additionally, since Starlette is now at 1.0, I think Stable is the appropriate one to link to.

@Kludex If you have any issues, please let me know.