### PR TITLE
Fix bug where assigning `_data` onto `Local` would corrupt it

### DIFF
--- a/asgiref/local.py
+++ b/asgiref/local.py
@@ -34,13 +34,16 @@ def _rehome(storage: "_Storage") -> "_Storage":
     return _Storage(threading.get_ident(), storage.data)
 
 
+_object_setattr = object.__setattr__
+
+
 class _CVar:
     """Storage utility for Local."""
 
+    _data: "contextvars.ContextVar[_Storage]"
+
     def __init__(self) -> None:
-        self._data: "contextvars.ContextVar[_Storage]" = contextvars.ContextVar(
-            "asgiref.local"
-        )
+        _object_setattr(self, "_data", contextvars.ContextVar("asgiref.local"))
 
     def _storage(self) -> "_Storage":
         # Only return storage that belongs to the current thread. Storage with
@@ -59,7 +62,7 @@ class _CVar:
 
     def __setattr__(self, key: str, value: Any) -> None:
         if key == "_data":
-            return super().__setattr__(key, value)
+            raise AttributeError("Cannot set attribute '_data' on Local")
 
         data = self._storage().data.copy()
         data[key] = value

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -431,3 +431,13 @@ async def test_deletion() -> None:
 
     await asyncio.create_task(_test())
     assert test_local.value == 123
+
+
+def test_data_name_protected() -> None:
+    test_local = Local()
+    test_local.important = "keep me"
+    # ``_data`` is the name ``_CVar`` uses for its backing ContextVar,
+    # so it may not be set by user code.
+    with pytest.raises(AttributeError):
+        test_local._data = "user supplied value"
+    assert test_local.important == "keep me"


### PR DESCRIPTION
Found as part of #551.

Very special corner case, but previously `Local()._data = "foo"` would make the whole instance unusable.