### PR TITLE
upstreaming a fix for a small bug - compare contextvars by identity in _restore_context

### DIFF
--- a/asgiref/sync.py
+++ b/asgiref/sync.py
@@ -46,7 +46,7 @@ def _restore_context(context: contextvars.Context) -> None:
         if isinstance(cvalue, _Storage):
             cvalue = _rehome(cvalue)
         try:
-            if cvar.get() != cvalue:
+            if cvar.get() is not cvalue:
                 cvar.set(cvalue)
         except LookupError:
             cvar.set(cvalue)

--- a/tests/test_sync_contextvars.py
+++ b/tests/test_sync_contextvars.py
@@ -3,6 +3,7 @@ import contextvars
 import sys
 import threading
 import time
+from collections.abc import Mapping
 
 import pytest
 
@@ -162,3 +163,43 @@ async def test_sync_to_async_contextvars_with_callable_with_context_attribute():
     async_function = sync_to_async(SyncCallable())
     assert async_function.context is None
     assert await async_function() == 42
+
+
+class ConcurrentlyMutatedMapping(Mapping):
+    """Stands in for a WeakValueDictionary that is mutated while being iterated.
+
+    ``Mapping.__eq__`` is implemented as ``dict(self) == dict(other)``, so any
+    equality comparison iterates the mapping. A ``WeakValueDictionary`` shared
+    across threads can raise from that iteration if another thread inserts a key
+    or a weakref is reaped part-way through.
+    """
+
+    def __init__(self, data):
+        self._data = dict(data)
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        raise RuntimeError("dictionary changed size during iteration")
+
+
+cache: "contextvars.ContextVar[ConcurrentlyMutatedMapping]" = contextvars.ContextVar(
+    "cache"
+)
+
+
+@pytest.mark.asyncio
+async def test_restore_context_does_not_compare_values_by_equality():
+    """Restoring contextvars must not invoke third-party ``__eq__``."""
+
+    def sync_function():
+        # Replace the value with an equal-but-distinct object, as a library
+        # rebuilding its cache would.
+        cache.set(ConcurrentlyMutatedMapping({"a": 1}))
+
+    cache.set(ConcurrentlyMutatedMapping({"a": 1}))
+    await sync_to_async(sync_function)()

--- a/tests/test_sync_contextvars.py
+++ b/tests/test_sync_contextvars.py
@@ -165,7 +165,7 @@ async def test_sync_to_async_contextvars_with_callable_with_context_attribute():
     assert await async_function() == 42
 
 
-class ConcurrentlyMutatedMapping(Mapping):
+class ConcurrentlyMutatedMapping(Mapping[str, int]):
     """Stands in for a WeakValueDictionary that is mutated while being iterated.
 
     ``Mapping.__eq__`` is implemented as ``dict(self) == dict(other)``, so any


### PR DESCRIPTION
hi. long time first time. 

This is a one line fix to compare by identity with `is not` instead of `!=` in `_restore_context`.

This is important if what you're restoring is from pydantic and using a `WeakValueDictionary`, which if comparing dicts would not really do a full comparison. There are likely other places where this would come up. But I can confirm that this broke a few times in prod at my $job, and that this fix is already running well in production for us.

previous history on this file:
https://github.com/django/asgiref/pull/148
https://github.com/django/asgiref/pull/390

doesn't seem like either one required `!=` in particular. I think `is not` should be strictly better.

not sure if we want to keep the test? it does work with red/green but it's a bit contrived.