### PR TITLE
Clarify Early Hints message ordering

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -188,8 +188,7 @@ scope::
 
 An ASGI framework can send an early hint by sending a message with the
 following keys. This message can be sent at any time (and multiple
-times) after the *Response Start* message but before the final
-*Response Body* message.
+times) before the *Response Start* message.
 
 Keys:
 


### PR DESCRIPTION
## Summary

Clarify that `http.response.early_hint` messages are sent before the `http.response.start` message.

## Rationale

The current wording places Early Hints after Response Start. Hypercorn's implementation accepts Early Hints while the stream is in the request state and transitions out of that state when it receives Response Start, establishing the ordering Early Hints → Response Start → Response Body:

https://github.com/pgjones/hypercorn/blob/0e2311f1ad2ae587aaa590f3824f59aa5dc0e770/src/hypercorn/protocol/http_stream.py#L142-L186

This also reflects the HTTP wire ordering, where the informational `103` response precedes the final response.

## Testing

- `sphinx-build -b html docs /tmp/asgiref-docs-build`
