### PR TITLE
Add Veloce to implementations

### DIFF
--- a/docs/implementations.rst
+++ b/docs/implementations.rst
@@ -206,6 +206,16 @@ enables high-concurrency web apps with built-in WebSockets, session management,
 middleware, and optional template rendering with method based routing.
 
 
+Veloce
+------
+
+*Beta* / https://veloceframework.com/
+
+Veloce is an ASGI framework written from scratch, in which one route definition
+drives HTTP dispatch, the OpenAPI schema, and an opt-in MCP tool surface, so the
+three stay in step. Supports HTTP, WebSockets and Server-Sent Events.
+
+
 Tools
 =====
 


### PR DESCRIPTION
Adds Veloce to the Application Frameworks list, appended to the end of the section as recent additions have been.

Veloce is an ASGI-native Python web framework written from scratch rather than on top of an existing toolkit. Each route is compiled once at registration into a plan holding its dependency graph and declared input/output types, and that single plan drives HTTP dispatch, the OpenAPI 3.1 document, and an opt-in MCP tool surface.

- Docs: https://veloceframework.com/
- Source: https://github.com/Lokesh-Tallapaneni/veloce
- PyPI: https://pypi.org/project/veloceframework/
- Supports HTTP, WebSockets and Server-Sent Events; asyncio, with uvloop optional.
- MIT licensed, ships `py.typed`, Python 3.10+.

Marked *Beta* to match the project's own `Development Status :: 4 - Beta` classifier.
