### PR TITLE
Add support for Python 3.15 and drop 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { python-version: '3.10',  toxenv: 'py310-test,py310-mypy' }
         - { python-version: '3.11',  toxenv: 'py311-test,py311-mypy' }
         - { python-version: '3.12',  toxenv: 'py312-test,py312-mypy' }
         - { python-version: '3.13',  toxenv: 'py313-test,py313-mypy' }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,10 @@ jobs:
         - { python-version: '3.12',  toxenv: 'py312-test,py312-mypy' }
         - { python-version: '3.13',  toxenv: 'py313-test,py313-mypy' }
         - { python-version: '3.14',  toxenv: 'py314-test,py314-mypy' }
+        - { python-version: '3.15',  toxenv: 'py315-test,py315-mypy' }
         - { python-version: '3.13t', toxenv: 'py313t-test' }
         - { python-version: '3.14t', toxenv: 'py314t-test' }
+        - { python-version: '3.15t', toxenv: 'py315t-test' }
 
     steps:
       - uses: actions/checkout@v7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: ["--py310-plus"]
+        args: ["--py311-plus"]
 
   - repo: https://github.com/psf/black
     rev: 26.5.1
     hooks:
       - id: black
-        args: ["--target-version=py310"]
+        args: ["--target-version=py311"]
 
   - repo: https://github.com/pycqa/isort
     rev: 8.0.1

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ file handles for incoming POST bodies).
 Dependencies
 ------------
 
-``asgiref`` requires Python 3.10 or higher.
+``asgiref`` requires Python 3.11 or higher.
 
 
 Contributing

--- a/asgiref/testing.py
+++ b/asgiref/testing.py
@@ -108,7 +108,7 @@ class ApplicationCommunicator:
         try:
             async with async_timeout(timeout):
                 return await self.output_queue.get()
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             # See if we have another error to raise inside
             if self.future.done():
                 self.future.result()

--- a/asgiref/timeout.py
+++ b/asgiref/timeout.py
@@ -105,7 +105,7 @@ class timeout:
         if exc_type is asyncio.CancelledError and self._cancelled:
             self._cancel_handler = None
             self._task = None
-            raise asyncio.TimeoutError
+            raise TimeoutError
         if self._timeout is not None and self._cancel_handler is not None:
             self._cancel_handler.cancel()
             self._cancel_handler = None

--- a/asgiref/typing.py
+++ b/asgiref/typing.py
@@ -1,11 +1,5 @@
-import sys
 from collections.abc import Awaitable, Callable, Iterable
-from typing import Any, Literal, Protocol, TypedDict, Union
-
-if sys.version_info >= (3, 11):
-    from typing import NotRequired
-else:
-    from typing_extensions import NotRequired
+from typing import Any, Literal, NotRequired, Protocol, TypedDict, Union
 
 __all__ = (
     "ASGIVersions",

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
@@ -29,11 +28,9 @@ project_urls =
     Changelog = https://github.com/django/asgiref/blob/master/CHANGELOG.txt
 
 [options]
-python_requires = >=3.10
+python_requires = >=3.11
 packages = find:
 include_package_data = true
-install_requires =
-    typing_extensions>=4; python_version < "3.11"
 zip_safe = false
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.14
+    Programming Language :: Python :: 3.15
     Programming Language :: Python :: Free Threading :: 2 - Beta
     Topic :: Internet :: WWW/HTTP
 project_urls =

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,7 +2,6 @@ import asyncio
 import contextvars
 import functools
 import multiprocessing
-import sys
 import threading
 import time
 import warnings
@@ -1084,7 +1083,7 @@ async def test_sync_to_async_with_blocker_thread_sensitive():
         # wait on the event waiter, which is now blocking the event setter.
         async with timeout(delay + 1):
             assert await async_process_waiting_on_event() == 42
-    except asyncio.TimeoutError:
+    except TimeoutError:
         # In case of timeout, set the event to unblock things, else
         # downstream tests will get fouled up.
         event.set()
@@ -1119,7 +1118,7 @@ async def test_sync_to_async_with_blocker_non_thread_sensitive():
         # wait on the event waiter, which is now blocking the event setter.
         async with timeout(delay + 1):
             assert await async_process_waiting_on_event() == 42
-    except asyncio.TimeoutError:
+    except TimeoutError:
         # In case of timeout, set the event to unblock things, else
         # downstream tests will get fouled up.
         event.set()
@@ -1516,30 +1515,30 @@ def test_double_nested_task() -> None:
 
 # asyncio.Barrier is new in Python 3.11. Nest definition (rather than using
 # skipIf) to avoid mypy error.
-if sys.version_info >= (3, 11):
 
-    def test_two_nested_tasks_with_asyncio_run() -> None:
-        barrier = asyncio.Barrier(3)
-        event = threading.Event()
 
-        async def inner() -> None:
-            task = asyncio.create_task(sync_to_async(event.wait)())
-            await barrier.wait()
-            await task
+def test_two_nested_tasks_with_asyncio_run() -> None:
+    barrier = asyncio.Barrier(3)
+    event = threading.Event()
 
-        async def outer() -> tuple[asyncio.Task[None], asyncio.Task[None]]:
-            task0 = asyncio.create_task(inner())
-            task1 = asyncio.create_task(inner())
-            await barrier.wait()
-            event.set()
-            return task0, task1
+    async def inner() -> None:
+        task = asyncio.create_task(sync_to_async(event.wait)())
+        await barrier.wait()
+        await task
 
-        async def main() -> None:
-            task0, task1 = await sync_to_async(async_to_sync(outer))()
-            await task0
-            await task1
+    async def outer() -> tuple[asyncio.Task[None], asyncio.Task[None]]:
+        task0 = asyncio.create_task(inner())
+        task1 = asyncio.create_task(inner())
+        await barrier.wait()
+        event.set()
+        return task0, task1
 
-        asyncio.run(main())
+    async def main() -> None:
+        task0, task1 = await sync_to_async(async_to_sync(outer))()
+        await task0
+        await task1
+
+    asyncio.run(main())
 
 
 def test_async_to_sync_with_stopped_main_loop():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313,314,315}-{test,mypy}
+    py{311,312,313,314,315}-{test,mypy}
     py{313,314,315}t-test
     qa
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{310,311,312,313,314}-{test,mypy}
-    py{313,314}t-test
+    py{310,311,312,313,314,315}-{test,mypy}
+    py{313,314,315}t-test
     qa
 
 [testenv]
@@ -22,6 +22,9 @@ basepython = python3.13t
 
 [testenv:py314t-test]
 basepython = python3.14t
+
+[testenv:py315t-test]
+basepython = python3.15t
 
 [testenv:qa]
 skip_install = true


### PR DESCRIPTION
This explicitly declares support for Python 3.15 via classifiers and enables testing in Python 3.15 and 3.15t. It also drops support for Python 3.10

All tests passed locally :)

```
  py311-test: OK (14.59=setup[1.48]+cmd[13.11] seconds)
  py311-mypy: OK (3.66=setup[3.48]+cmd[0.18] seconds)
  py312-test: OK (15.31=setup[2.17]+cmd[13.14] seconds)
  py312-mypy: OK (2.91=setup[2.74]+cmd[0.17] seconds)
  py313-test: OK (16.20=setup[2.97]+cmd[13.23] seconds)
  py313-mypy: OK (3.66=setup[3.46]+cmd[0.20] seconds)
  py314-test: OK (14.06=setup[0.86]+cmd[13.20] seconds)
  py314-mypy: OK (2.91=setup[2.72]+cmd[0.20] seconds)
  py315-test: OK (14.00=setup[0.81]+cmd[13.19] seconds)
  py315-mypy: OK (1.69=setup[1.51]+cmd[0.18] seconds)
  py313t-test: OK (14.38=setup[1.01]+cmd[13.37] seconds)
  py314t-test: OK (14.94=setup[1.72]+cmd[13.22] seconds)
  py315t-test: OK (14.76=setup[1.51]+cmd[13.25] seconds)
  qa: OK (1.60=setup[0.01]+cmd[1.60] seconds)
  congratulations :) (19.41 seconds)
```