### PR TITLE
Resolve "Drop the versionless License :: classifier now that license is a valid SPDX expression"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Intended Audience :: Developers
-    License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3


### PR DESCRIPTION

Dropping the deprecated classifier.

Tested the change using by creating the SBOM as demonstrated in the issue and observing the absence of the legacy classifier.

Closes #583 