### PR TITLE
Call uncancel() when timeout swallows its own CancelledError

### DIFF
--- a/asgiref/timeout.py
+++ b/asgiref/timeout.py
@@ -103,6 +103,8 @@ class timeout:
 
     def _do_exit(self, exc_type: type[BaseException]) -> None:
         if exc_type is asyncio.CancelledError and self._cancelled:
+            if self._task is not None and hasattr(self._task, "uncancel"):
+                self._task.uncancel()
             self._cancel_handler = None
             self._task = None
             raise asyncio.TimeoutError

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,41 @@
+import asyncio
+
+import pytest
+
+from asgiref.timeout import timeout
+
+
+@pytest.mark.asyncio
+async def test_timeout_uncancels_task_on_expiry():
+    """
+    When the timeout expires and swallows the CancelledError it raised,
+    it should also uncancel() the task so the cancel it issued doesn't
+    linger on the task's cancel count.
+    """
+    task = asyncio.current_task()
+    assert task is not None
+    cancelling_before = task.cancelling()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout(0.01):
+            await asyncio.sleep(1)
+
+    assert task.cancelling() == cancelling_before
+
+
+@pytest.mark.asyncio
+async def test_timeout_does_not_uncancel_unrelated_cancellation():
+    """
+    If the block raises a CancelledError that isn't the one the timeout
+    itself triggered, the CancelledError should propagate untouched and
+    no uncancel() should happen.
+    """
+    task = asyncio.current_task()
+    assert task is not None
+    cancelling_before = task.cancelling()
+
+    with pytest.raises(asyncio.CancelledError):
+        async with timeout(10):
+            raise asyncio.CancelledError
+
+    assert task.cancelling() == cancelling_before


### PR DESCRIPTION
Closes #504.

When `asgiref.timeout`'s deadline fires, it calls `task.cancel()` and then catches the resulting `CancelledError` to turn it into a `TimeoutError`. Since Python 3.11 added `Task.uncancel()` and the `cancelling()` counter, any code that suppresses a `CancelledError` it caused itself is expected to call `uncancel()` to balance that count back out, same as the stdlib `asyncio.timeout()` context manager already does.

Without this, `task.cancelling()` stays elevated after the timeout has been handled, which can confuse other code checking that counter to decide whether a cancellation is still pending, or cause an outer cancel scope to misbehave when this timeout is nested inside it.

Guarded with `hasattr` since `uncancel()` only exists on Python 3.11+ and this package still supports 3.10.

Added two tests: one confirming the cancel count is restored after the timeout fires and is handled, and one confirming an unrelated `CancelledError` (not caused by this timeout) still propagates and isn't touched.

Ran the full test suite locally (100 passed, 1 pre-existing xfail) plus black/isort/flake8 on the touched files.