### PR TITLE
Call close() on the WSGI response iterable in WsgiToAsgi

### DIFF
--- a/asgiref/wsgi.py
+++ b/asgiref/wsgi.py
@@ -172,24 +172,33 @@ class WsgiToAsgiInstance:
             return
         # Run the WSGI app
         bytes_sent = 0
-        for output in self.wsgi_application(environ, self.start_response):
-            # If this is the first response, include the response headers
-            if not self.response_started:
-                self.response_started = True
-                self.sync_send(self.response_start)
-            # If the application supplies a Content-Length header
-            if self.response_content_length is not None:
-                # The server should not transmit more bytes to the client than the header allows
-                bytes_allowed = self.response_content_length - bytes_sent
-                if len(output) > bytes_allowed:
-                    output = output[:bytes_allowed]
-            self.sync_send(
-                {"type": "http.response.body", "body": output, "more_body": True}
-            )
-            bytes_sent += len(output)
-            # The server should stop iterating over the response when enough data has been sent
-            if bytes_sent == self.response_content_length:
-                break
+        result = self.wsgi_application(environ, self.start_response)
+        try:
+            for output in result:
+                # If this is the first response, include the response headers
+                if not self.response_started:
+                    self.response_started = True
+                    self.sync_send(self.response_start)
+                # If the application supplies a Content-Length header
+                if self.response_content_length is not None:
+                    # The server should not transmit more bytes to the client than the header allows
+                    bytes_allowed = self.response_content_length - bytes_sent
+                    if len(output) > bytes_allowed:
+                        output = output[:bytes_allowed]
+                self.sync_send(
+                    {"type": "http.response.body", "body": output, "more_body": True}
+                )
+                bytes_sent += len(output)
+                # The server should stop iterating over the response when enough data has been sent
+                if bytes_sent == self.response_content_length:
+                    break
+        finally:
+            # PEP 3333 requires the gateway to call close() on the response
+            # iterable, whether iteration completed normally or was terminated
+            # early, so that the application can release its resources.
+            close = getattr(result, "close", None)
+            if close is not None:
+                close()
         # Close connection
         if not self.response_started:
             self.response_started = True

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -380,3 +380,126 @@ async def test_duplicate_header_limit_disabled():
         "more_body": True,
     }
     assert (await instance.receive_output(1)) == {"type": "http.response.body"}
+
+
+class ClosingIterable:
+    """
+    A WSGI response iterable that records whether close() was called.
+    """
+
+    def __init__(self, chunks):
+        self.chunks = iter(chunks)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self.chunks)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.parametrize("headers", [[], [("Content-Length", "10")]])
+@pytest.mark.asyncio
+async def test_wsgi_closes_response_iterable(headers):
+    """
+    PEP 3333 requires the gateway to call close() on the response iterable once
+    the request is complete.
+    """
+    body = ClosingIterable([b"hello", b"world"])
+
+    def wsgi_application(environ, start_response):
+        start_response("200 OK", headers)
+        return body
+
+    application = WsgiToAsgi(wsgi_application)
+    instance = ApplicationCommunicator(
+        application,
+        {
+            "type": "http",
+            "http_version": "1.0",
+            "method": "GET",
+            "path": "/",
+            "query_string": b"",
+            "headers": [],
+        },
+    )
+    await instance.send_input({"type": "http.request"})
+    while (await instance.receive_output(1)) != {"type": "http.response.body"}:
+        pass
+
+    assert body.closed
+
+
+@pytest.mark.asyncio
+async def test_wsgi_closes_response_iterable_when_truncated():
+    """
+    close() is called even though iteration stops early because Content-Length
+    bytes have already been sent.
+    """
+    body = ClosingIterable([b"hello", b"world"])
+
+    def wsgi_application(environ, start_response):
+        start_response("200 OK", [("Content-Length", "5")])
+        return body
+
+    application = WsgiToAsgi(wsgi_application)
+    instance = ApplicationCommunicator(
+        application,
+        {
+            "type": "http",
+            "http_version": "1.0",
+            "method": "GET",
+            "path": "/",
+            "query_string": b"",
+            "headers": [],
+        },
+    )
+    await instance.send_input({"type": "http.request"})
+    while (await instance.receive_output(1)) != {"type": "http.response.body"}:
+        pass
+
+    assert body.closed
+    # The rest of the iterable was never consumed.
+    assert next(body.chunks) == b"world"
+
+
+@pytest.mark.asyncio
+async def test_wsgi_closes_response_iterable_on_error():
+    """
+    close() is called when the application raises part way through iteration.
+    """
+
+    class ExplodingIterable(ClosingIterable):
+        def __next__(self):
+            chunk = super().__next__()
+            if chunk is None:
+                raise ValueError("application error")
+            return chunk
+
+    body = ExplodingIterable([b"hello", None])
+
+    def wsgi_application(environ, start_response):
+        start_response("200 OK", [])
+        return body
+
+    application = WsgiToAsgi(wsgi_application)
+    instance = ApplicationCommunicator(
+        application,
+        {
+            "type": "http",
+            "http_version": "1.0",
+            "method": "GET",
+            "path": "/",
+            "query_string": b"",
+            "headers": [],
+        },
+    )
+    await instance.send_input({"type": "http.request"})
+    with pytest.raises(ValueError, match="application error"):
+        while True:
+            await instance.receive_output(1)
+
+    assert body.closed


### PR DESCRIPTION
`WsgiToAsgiInstance.run_wsgi_app` iterates the WSGI application's return value and then drops it. It never calls `close()`, on any exit path — normal completion, the deliberate early `break` when `Content-Length` bytes have been sent, or an exception raised during iteration. `grep -rn '\.close()' asgiref/` finds no call anywhere in the package.

PEP 3333, "Specification Details":

> If the iterable returned by the application has a `close()` method, the server or gateway **must** call that method upon completion of the current request, whether the request was completed normally, or terminated early due to an application error during iteration or an early disconnect of the browser.

Control, same iterable object handed to the stdlib gateway:

```
asgiref: no Content-Length, normal completion        body=b'helloworld'  close_called=False
asgiref: Content-Length exact                        body=b'helloworld'  close_called=False
asgiref: Content-Length short (early break)          body=b'hello'       close_called=False
CONTROL stdlib wsgiref.handlers.SimpleHandler                            close_called=True
```

The early-`break` case is the one that bites in practice: with a generator body the frame is left suspended at its `yield`, so its `finally:` never runs deterministically. Django's `HttpResponse.close()` is that shape — it sends `request_finished`, which closes obsolete DB connections — so a Django WSGI app behind `WsgiToAsgi` misses its per-request teardown. The fix wraps the existing loop in `try`/`finally` and calls `close()` if present.

Why no test caught it: six of the nine WSGI apps in `tests/test_wsgi.py` return a plain `list`, which has no `close()`. `test_wsgi_stops_iterating_after_content_length_bytes` is the one test that exercises the early break, but its only guard is a `pytest.fail()` after the `yield`, and `close()` on a suspended generator throws `GeneratorExit` *at* the suspension point rather than resuming past it — so that guard cannot fire either way. No test in the suite builds a response iterable with a `close()` method.

Ran: `pytest` (102 passed, 1 xfailed) on CPython 3.14, and `black` 26.5.1 / `isort` 8.0.1 / `flake8` 7.3.0 / `pyupgrade` 3.21.2 at the versions `.pre-commit-config.yaml` pins, plus `mypy` on the changed module. Mutants: reverting `wsgi.py` fails all four new tests and no others; a naive fix that calls `close()` after the loop instead of in a `finally` passes 13 and fails only the error-path test, which is what pins `try`/`finally` rather than merely "call close()".

Not verified: I did not exercise this behind a real ASGI server or a real Django `WSGIHandler` — the Django consequence above is inferred from `HttpResponse.close()`'s contract, not executed here. I also did not test the "early disconnect of the browser" arm of the PEP requirement; `WsgiToAsgi` doesn't observe `http.disconnect` at all, which looks like a separate gap and is out of scope here. No changelog entry added, since those appear to be written at release time.

AI assistance disclosure: investigated and drafted with the help of Claude Opus 5 (`claude-opus-5`). The mechanism, repro, mutants and every command above were run and checked before submitting.

